### PR TITLE
feat(configurable-plans-dir): make the plans directory configurable via .claude/hcf.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to HCF are documented here. Format follows [Keep a Changelog
 
 ## [Unreleased]
 
+### Added
+- **Configurable plans directory** via optional `.claude/hcf.json` (key: `plansDir`). Defaults to `.claude/plans`; no skill creates or modifies the file, so regular users see zero change. Absolute paths and `..` segments are rejected with a silent fallback to the default. Changing `plansDir` after plans exist requires moving existing plan folders manually.
+
 ## [1.1.1] — 2026-05-01
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Autonomous development plugin for Claude Code. Define requirements with a PM, th
   - [Task Format](#task-format)
   - [Skills](#skills)
   - [Outputs](#outputs)
+- [Advanced Configuration](#advanced-configuration)
+  - [Plans Directory](#plans-directory)
 - [Architecture](#architecture)
 - [Design Principles](#design-principles)
 - [Development](#development)
@@ -227,7 +229,7 @@ Each task follows strict Red → Green → Refactor:
 | `architecture.md` | Directory structure, patterns |
 | `pipeline.md` | Workflow agent configuration |
 
-#### Plans (`.claude/plans/{name}/`)
+#### Plans (`.claude/plans/{name}/`, configurable via `.claude/hcf.json`)
 
 | File | Purpose |
 |------|---------|
@@ -273,6 +275,30 @@ All skills can be invoked directly with `/skill-name` or triggered automatically
 |--------|---------|
 | `ALL_TASKS_COMPLETE` | Plan finished successfully |
 | `TASKS_BLOCKED: [003, 007]` | Some tasks failed after retries |
+
+## Advanced Configuration
+
+HCF works out of the box with no extra config. The options below are for power users who need to customize behavior.
+
+### Plans Directory
+
+By default, HCF stores plan files in `.claude/plans/`. You can override this with an optional config file at `.claude/hcf.json`:
+
+```json
+{
+  "plansDir": "docs/plans"
+}
+```
+
+`plansDir` is a path relative to the project root. If the key is absent, the file is missing, or the value is invalid, HCF falls back to `.claude/plans`.
+
+**Rules for `plansDir`:**
+- Must be a relative path inside the repo.
+- Absolute paths (starting with `/`) and any path containing `..` are invalid and will be ignored with a silent fallback to `.claude/plans`.
+
+**No skill ever creates or modifies `.claude/hcf.json`.** Regular users can ignore this file entirely; it exists only when you create it.
+
+**Caveat:** changing `plansDir` after plans already exist means moving the existing plan folders manually. HCF does not migrate them. Keep the plans directory git-tracked (not gitignored) since plan files are committed with the work.
 
 ## Architecture
 

--- a/agents/devils-advocate.md
+++ b/agents/devils-advocate.md
@@ -29,11 +29,12 @@ You are a Devil's Advocate architectural reviewer. Your job is to critically ana
 11. **Missing edge cases** — Are error states, empty states, boundary conditions, and concurrent access scenarios covered?
 
 **Process:**
-1. Read ALL task files in the plan directory
-2. Read the `_plan.md` for the overall architecture
-3. Cross-reference against project architecture docs and code standards where relevant
-4. Cross-reference against actual source files where relevant (e.g., verify that targeted methods/classes exist and have the expected signatures)
-5. Write your findings to `.claude/plans/{plan-name}/_devils_advocate.md`
+1. Determine the plan directory: use the path given under the `## Plan Directory` heading in the prompt. If no such heading is present, fall back to `.claude/plans/{plan-name}/`.
+2. Read ALL task files in the plan directory
+3. Read the `_plan.md` for the overall architecture
+4. Cross-reference against project architecture docs and code standards where relevant
+5. Cross-reference against actual source files where relevant (e.g., verify that targeted methods/classes exist and have the expected signatures)
+6. Write your findings to `{plan directory}/_devils_advocate.md` (using the path from step 1)
 
 **Output format for the findings file:**
 ```markdown

--- a/agents/tdd-worker.md
+++ b/agents/tdd-worker.md
@@ -7,6 +7,14 @@ tools: Read, Write, Edit, Bash, Glob, Grep
 
 You are a TDD programmer implementing a single task. Work autonomously until complete.
 
+## Task File
+
+Read your task file from the concrete path given under the `## Task File Path` heading of the prompt you received. Use that path for all reads and writes: reading requirements, marking checkboxes `[x]`, and adding implementation notes.
+
+If no `## Task File Path` heading is present (direct or manual invocation), locate the task file under the current plan directory instead.
+
+Never read `.claude/hcf.json` to resolve the path.
+
 ## TDD Process (STRICT)
 
 Use the test commands from the project testing configuration provided in your prompt. Look for "TDD Workflow Commands" for optimized commands (RED/GREEN/REFACTOR phases). If not present, use the standard test command.

--- a/skills/plan-create/SKILL.md
+++ b/skills/plan-create/SKILL.md
@@ -82,6 +82,20 @@ Present in this order:
 - Each "must answer" should be a decision that, if assumed wrong, would force a rewrite. Each "will default" should be safe to assume with a stated default the user can override.
 - If the Phase 1 quick scope check determined the ask was already concrete, skip to Phase 3 with no questions asked.
 
+### Resolve Plans Directory
+
+Before Phase 3, resolve the plans directory once and reuse the result everywhere:
+
+```bash
+PLANS_DIR=$(jq -r '.plansDir // ".claude/plans"' .claude/hcf.json 2>/dev/null || echo ".claude/plans")
+[ -z "$PLANS_DIR" ] && PLANS_DIR=".claude/plans"
+case "$PLANS_DIR" in /*|..*|*/..*) PLANS_DIR=".claude/plans";; esac
+```
+
+If `.claude/hcf.json` exists and contains a `plansDir` key, use its value. If the file is missing, unreadable, or the key is absent, fall back to `.claude/plans`. Absolute paths and any `..` segment are also rejected and fall back to the default.
+
+Use `$PLANS_DIR/{plan-name}/...` in every subsequent path.
+
 ### Phase 3: Define the Plan
 
 Once you understand the requirements, create the plan overview:
@@ -98,7 +112,7 @@ git checkout feature/{plan-name}
 
 **Create plan directory:**
 ```bash
-mkdir -p .claude/plans/{plan-name}
+mkdir -p $PLANS_DIR/{plan-name}
 ```
 
 Use a kebab-case name derived from the feature (e.g., `user-authentication`, `payment-processing`).
@@ -235,7 +249,13 @@ Parse the `## post-plan` section from the `<pipeline>` context included in CLAUD
 Use the Agent tool with `subagent_type="{agent-name}"` and pass the plan name and project context.
 
 **The subagent prompt must include:**
-1. The plan name (so it knows the directory path)
+1. The concrete resolved plan directory (so it has the exact path without needing to read `hcf.json`):
+
+```
+## Plan Directory
+$PLANS_DIR/{plan-name}
+```
+
 2. The project's architecture context:
 
 ```
@@ -301,7 +321,7 @@ Once approved:
 ```
 Plan created: {plan-name}
 
-Location: .claude/plans/{plan-name}/
+Location: $PLANS_DIR/{plan-name}/
 Total tasks: {N}
 Independent tasks (batch 1): {count of tasks with no dependencies}
 ```

--- a/skills/plan-orchestrate/SKILL.md
+++ b/skills/plan-orchestrate/SKILL.md
@@ -18,15 +18,27 @@ plan-orchestrate {plan-name}
 
 Example: `plan-orchestrate user-auth`
 
+## Resolve Plans Directory
+
+Before checking prerequisites, resolve the plans directory once. If `.claude/hcf.json` exists and contains a `plansDir` key, use its value; otherwise use `.claude/plans` as the default.
+
+```bash
+PLANS_DIR=$(jq -r '.plansDir // ".claude/plans"' .claude/hcf.json 2>/dev/null || echo ".claude/plans")
+[ -z "$PLANS_DIR" ] && PLANS_DIR=".claude/plans"
+case "$PLANS_DIR" in /*|..*|*/..*) PLANS_DIR=".claude/plans";; esac
+```
+
+Use `$PLANS_DIR/{plan-name}/...` in every subsequent path reference.
+
 ## Prerequisites
 
-1. Plan must exist at `.claude/plans/{plan-name}/`
+1. Plan must exist at `$PLANS_DIR/{plan-name}/`
 2. Project must be configured (`.claude/testing.md` exists)
 3. Plan status must be `ready` or `in_progress`
 
 Check prerequisites:
 ```bash
-ls .claude/plans/{plan-name}/_plan.md .claude/testing.md 2>/dev/null
+ls $PLANS_DIR/{plan-name}/_plan.md .claude/testing.md 2>/dev/null
 ```
 
 If not found, output error and stop.
@@ -85,8 +97,8 @@ Before starting execution, check if the ralph-wiggum plugin is installed by look
 ### Step 1: Load Plan Context
 
 Read plan files:
-- `.claude/plans/{plan-name}/_plan.md` - Plan overview
-- `.claude/plans/{plan-name}/*.md` - All task files (excluding _plan.md)
+- `$PLANS_DIR/{plan-name}/_plan.md` - Plan overview
+- `$PLANS_DIR/{plan-name}/*.md` - All task files (excluding _plan.md)
 
 Note: Testing and code standards are auto-included above.
 
@@ -102,7 +114,7 @@ Build a dependency graph as a data structure.
 ### Step 2: Update Plan Status
 
 If plan status is `ready`, change to `in_progress`:
-- Edit `.claude/plans/{plan-name}/_plan.md`
+- Edit `$PLANS_DIR/{plan-name}/_plan.md`
 - Set `## Status` to `in_progress`
 
 ### Step 3: Find Ready Tasks
@@ -200,10 +212,10 @@ Pass the plan name, changed files list, and any relevant project context.
 First, update `_plan.md` status to `completed`. Then stage and commit everything together in a **single commit**:
 ```bash
 # 1. Update plan status BEFORE committing
-# (edit .claude/plans/{plan-name}/_plan.md — set Status to "completed")
+# (edit $PLANS_DIR/{plan-name}/_plan.md — set Status to "completed")
 
 # 2. Stage everything: implementation + pipeline agent fixes + plan files (including updated status)
-git add -A .claude/plans/{plan-name}/
+git add -A $PLANS_DIR/{plan-name}/
 git add -A
 git commit -m "feat({plan-name}): {plan title summary}"
 ```
@@ -245,6 +257,9 @@ All Task tool calls MUST be made in a SINGLE message to enable parallel executio
 
 ## Code Standards
 {paste the COMPLETE content of <code-standards> verbatim — do NOT summarize}
+
+## Task File Path
+{absolute or repo-relative path to this task's .md file, e.g. $PLANS_DIR/{plan-name}/{task-file}.md}
 
 ## Your Task
 {contents of the task file}

--- a/skills/project-setup/SKILL.md
+++ b/skills/project-setup/SKILL.md
@@ -132,6 +132,8 @@ Create the `.claude/` directory and all config files:
 mkdir -p .claude
 ```
 
+> **Advanced configuration note**: `.claude/hcf.json` is an optional, user-owned config file. Setup never creates, modifies, or asks about it. If it already exists, leave it untouched. Advanced users create it manually to configure options such as a custom plans directory.
+
 **Add `.claude/ralph-loop.local.md` to `.gitignore`:**
 
 Check if `.gitignore` exists and whether it already contains the entry. If not, append it:

--- a/skills/project-update/SKILL.md
+++ b/skills/project-update/SKILL.md
@@ -65,6 +65,33 @@ Read the project's `CLAUDE.md` and verify it references the `.claude/` config fi
 
 Note any missing references.
 
+### Step 5b: Validate hcf.json (if present)
+
+`.claude/hcf.json` is an optional advanced configuration file that users create manually. Its absence is the normal case and must never be flagged or prompt a suggestion to create it.
+
+If `.claude/hcf.json` exists:
+
+1. Read and parse its contents.
+2. Extract the `plansDir` value.
+3. Apply each check below and collect any warnings. Use ⚠ for all findings here: nothing in this step is auto-fixable.
+
+**Check A: containment rule**
+
+If `plansDir` is an absolute path (starts with `/`) or contains `..` segments, add:
+> ⚠ `.claude/hcf.json` — `plansDir` value "{value}" is invalid (absolute path or `..` segment). HCF will fall back to `.claude/plans`.
+
+**Check B: directory existence**
+
+If `plansDir` passes Check A but the directory it references does not exist, add:
+> ⚠ `.claude/hcf.json` — `plansDir` "{value}" does not exist. Create it or correct the path.
+
+**Check C: stale default plans**
+
+If `plansDir` passes Check A and differs from `.claude/plans`, check whether `.claude/plans` still contains any subdirectories. If it does, add:
+> ⚠ `.claude/hcf.json` — `plansDir` is set to "{value}" but `.claude/plans` still contains plan folders. Move them to "{value}" or remove them if they are no longer needed.
+
+Never create, modify, or suggest creating `.claude/hcf.json`. Only report.
+
 ### Step 6: Report and Confirm
 
 Output a summary of everything found, using ✓ for current items, ✗ for items that need fixing, and ⚠ for items that need user attention:
@@ -90,7 +117,12 @@ CLAUDE.md References:
   ✓ testing.md — referenced
   ✓ code-standards.md — referenced
   ✓ architecture.md — referenced
+
+Advanced Config:
+  ✓ .claude/hcf.json — present (plansDir: ".claude/my-plans")
 ```
+
+If `.claude/hcf.json` is absent, omit the "Advanced Config" section entirely. Never list it as missing or suggest creating it.
 
 If there are any ✗ or ⚠ items, ask the user:
 > I found {N} items that need attention. Want me to fix them? I'll walk you through each one.


### PR DESCRIPTION
This PR makes the plans directory configurable. I personally don't want to tie the plans to the `.claude` directory: for me it makes more sense to place the plans directory directly in the root of the project, or maybe in a `docs/plans` folder for other projects.

This PR introduces an optional `.claude/hcf.json` config file with a single `plansDir` key:

```json
{
  "plansDir": "docs/plans"
}
```

This is an advanced option. Regular users should never have to think about it: no skill creates the file, project-setup never asks about it, and when the file or key is absent everything behaves exactly as it does today (.claude/plans).

## How it works

- plan-create and plan-orchestrate resolve the plans directory once at startup with a shared resolution snippet. A missing file, invalid JSON, or missing key all silently fall back to the default.
- plansDir must be a relative path inside the repo. Absolute paths and .. segments are rejected and fall back to .claude/plans.
- Subagents stay config-unaware. The orchestrator passes each tdd-worker its concrete task file path under a ## Task File Path heading, and plan-create passes the plan directory to post-plan agents under a ## Plan Directory heading. devils-advocate no longer hardcodes its findings path. Both agents keep a documented fallback for direct manual invocation.
- project-setup documents the file as user-owned and hands-off; the interactive flow is unchanged.
- project-update validates an existing hcf.json: it warns when plansDir escapes the repo, points to a directory that doesn't exist, or when .claude/plans still contains plan folders after a move. Report-only, it never auto-fixes.
- README gains an "Advanced Configuration" section documenting all of the above.

## Notes

- Changing plansDir on a project with existing plans means moving the plan folders manually; HCF does not migrate them.
- Minor version bump per the versioning policy; CHANGELOG entry added under [Unreleased].