### PR TITLE
Release 2.0.0: frontmatter-based hook pipeline

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "hcf",
       "source": "./",
       "description": "Autonomous development orchestration with parallel TDD execution",
-      "version": "1.1.1",
+      "version": "2.0.0",
       "homepage": "https://github.com/markshust/hcf",
       "license": "MIT",
       "keywords": ["tdd", "autonomous", "orchestration", "planning", "agents"]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hcf",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "Autonomous development orchestration with parallel TDD execution",
   "author": {
     "name": "Mark Shust",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to HCF are documented here. Format follows [Keep a Changelog
 
 ## [Unreleased]
 
+## [2.0.0] — 2026-06-26
+
+### Added
+- **8 lifecycle hook points** spanning the plan and implementation flow: `pre-plan` / `post-plan`, `pre-implementation` / `post-implementation`, `pre-batch` / `post-batch`, and `pre-commit` / `post-commit`. Agents enroll at a hook to run at that named moment.
+- **Agent-frontmatter pipeline fields** — agents declare their pipeline membership directly in YAML frontmatter: `phase` (the hook point to enroll at), `order` (run order within a hook; lower runs first, default `100`), and `mode` (`single` or `batch`, default `single`).
+- **`HOOKS.md`** — a new top-level reference doc that is the authoritative source for the hook system: the 8 hook points, the frontmatter schema, the agent discovery routine, and sort/tie-break rules.
+- **Migration hooks** (in `hooks/hooks.json`) — a `SessionStart` notice plus `PreToolUse` and `UserPromptExpansion` gates that detect a legacy `.claude/pipeline.md` and **block `plan-create`/`plan-orchestrate` until it is migrated** with `/project-update` (covering both Claude-invoked and directly-typed slash commands). `/project-update` itself is never blocked, so the fix is always available.
+- **`Feature Development` section in the generated `CLAUDE.md`** — `project-setup` now emits a project-agnostic section, placed as the **first section** (right after the title/description), that routes feature work through `hcf:plan-create` / `hcf:plan-orchestrate` and tells Claude never to use the built-in plan mode. Previously the generated `CLAUDE.md` had no such wiring, so the planning workflow relied entirely on the skill's auto-trigger and could be suppressed by other directives in `CLAUDE.md`; the prominent placement is deliberate so it overrides them.
+
+### Changed
+- The pipeline is now configured via **agent frontmatter** (`phase:`) instead of a central `pipeline.md`. Declaring a `phase` on any agent enrolls it; because the bundled `devils-advocate` declares a `phase`, frontmatter enrollment is always authoritative.
+- `plan-orchestrate` now reads each agent's `mode` field to decide how to spawn it (`single` vs `batch`) instead of inferring it from the agent body.
+- `project-setup` no longer creates `pipeline.md`.
+- `project-update` now **migrates** a legacy `pipeline.md` into agent frontmatter (and removes the file once migrated).
+- `project-update` now **adds a missing Feature Development section** to `CLAUDE.md` automatically (purely additive — it never touches an existing section). This carries the `plan-create` / `plan-orchestrate` wiring across an upgrade for projects set up before the section existed.
+- The **empty-hook fast path** now explicitly forbids *narrating* why a hook is empty, not just suppressing the resolved-order line. An empty hook is silent and internal — `plan-orchestrate` no longer "thinks out loud" about agent enrollment (e.g. "tdd-worker and standards-enforcer declare no phase → no-op") during a run. Documented in `HOOKS.md` and `plan-orchestrate`.
+- `project-setup` and `project-update` are now **command-only** (`disable-model-invocation: true`) — they cannot be invoked programmatically by another skill.
+
+### Removed
+- `pipeline.md` is **no longer read as configuration** — there is no runtime fallback. HCF enrolls agents exclusively via frontmatter. A leftover `.claude/pipeline.md` blocks the planning workflow until `/project-update` migrates it into agent frontmatter and removes the file.
+
 ## [1.1.1] — 2026-05-01
 
 ### Changed
@@ -41,7 +62,8 @@ Initial public release.
 - **GitHub issue linking** — `plan-create` captures issue references (`Closes #N`, `Relates to #N`) and `plan-orchestrate` includes them in PR bodies for auto-close on merge.
 - MIT license.
 
-[Unreleased]: https://github.com/markshust/hcf/compare/hcf--v1.1.1...HEAD
+[Unreleased]: https://github.com/markshust/hcf/compare/hcf--v2.0.0...HEAD
+[2.0.0]: https://github.com/markshust/hcf/compare/hcf--v1.1.1...hcf--v2.0.0
 [1.1.1]: https://github.com/markshust/hcf/compare/hcf--v1.1.0...hcf--v1.1.1
 [1.1.0]: https://github.com/markshust/hcf/compare/hcf--v1.0.0...hcf--v1.1.0
 [1.0.0]: https://github.com/markshust/hcf/releases/tag/hcf--v1.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,3 @@ This repo is a Claude Code plugin published via its own marketplace manifest. To
 <code-standards>
 @.claude/code-standards.md
 </code-standards>
-
-<pipeline>
-@.claude/pipeline.md
-</pipeline>

--- a/HOOKS.md
+++ b/HOOKS.md
@@ -1,0 +1,160 @@
+# HCF Hooks
+
+This is the authoritative reference for HCF's hook system. HCF uses
+**convention over configuration**: instead of a central registry, each agent
+declares its own pipeline membership in its frontmatter. The work skills
+(`plan-create`, `plan-orchestrate`) point here rather than duplicating this
+logic.
+
+The previous central registry (`pipeline.md`) is now **legacy**. See
+[Legacy `pipeline.md`](#legacy-pipelinemd) below for how it is detected and
+superseded.
+
+## Hook Points
+
+There are exactly **8** hook points. A hook point is a named moment in the
+plan/implementation flow at which enrolled agents run.
+
+| Hook                  | Fires                                                                  |
+|-----------------------|------------------------------------------------------------------------|
+| `pre-plan`            | Before `plan-create` Phase 1 (Discovery) begins                        |
+| `post-plan`           | `plan-create` Phase 6, after dependency validation                     |
+| `pre-implementation`  | `plan-orchestrate` after Step 2, before the first batch                |
+| `pre-batch`           | Each loop iteration, before Step 5 (spawn workers)                     |
+| `post-batch`          | Each loop iteration, after Step 6 (collect results)                    |
+| `post-implementation` | `plan-orchestrate` Step 4a, when all tasks are complete                |
+| `pre-commit`          | Step 4a, after the full test suite passes, before the commit          |
+| `post-commit`         | Step 4a, after the commit, before the push/PR prompt                   |
+
+### Why there is no `execution` hook
+
+There is deliberately **no** `execution` hook. In HCF, executing a plan **is**
+the implementation loop — the Step 3 → 5 → 6 → 8 batch cycle in
+`plan-orchestrate`. An `execution` hook would fire over that same span already
+covered by the `*-implementation` and `*-batch` hooks (`pre-implementation`,
+`pre-batch`, `post-batch`, `post-implementation`), so it would only duplicate
+what those hooks express. Use those instead.
+
+## Frontmatter Schema
+
+An agent enrolls itself in a hook by adding these keys to its YAML frontmatter,
+alongside the existing `name` / `description` / `model` / `tools` keys.
+
+```yaml
+---
+name: devils-advocate
+description: "..."
+model: opus
+tools: Read, Write, Edit, Glob, Grep
+# --- hook enrollment ---
+phase: post-plan   # enrolls this agent at the named hook point
+order: 100         # integer; lower runs first; default 100
+mode: single       # "single" | "batch"; default "single"
+---
+```
+
+| Key     | Type    | Default    | Meaning                                                                                  |
+|---------|---------|------------|------------------------------------------------------------------------------------------|
+| `phase` | string  | (none)     | The hook point that enrolls this agent. Must be one of the 8 hooks above.                |
+| `order` | integer | `100`      | Run order within a hook. Lower runs first. Equal values tie-break by `name`.            |
+| `mode`  | enum    | `single`   | How the agent is spawned: `single` (one subagent for the whole plan) or `batch` (files are split into batches of ~10 and spawned as parallel subagents). |
+
+### The enrollment rule
+
+**If an agent declares a `phase`, it runs.** There is no conditional
+evaluation. HCF intentionally has **no** `requires:` or `condition:` mechanism —
+a declared `phase` is an unconditional enrollment. To stop an agent from
+running at a hook, remove its `phase` key (or delete/override the agent); do not
+look for a condition to toggle.
+
+An agent with **no** `phase` key is simply not enrolled in any hook (e.g.
+`tdd-worker`, which the orchestrator spawns directly, never via a hook).
+
+## Discovery Routine
+
+This is the deterministic, stepwise routine a skill follows to resolve which
+agents run at a given hook. Follow it literally; do not improvise.
+
+Let `HOOK` be the hook point being run (one of the 8 above).
+
+1. **Glob local agents.** List `.claude/agents/*.md` in the current project.
+2. **Glob plugin agents.** List `*.md` in the plugin's `agents/` directory
+   (see [Resolving the plugin `agents/` directory](#resolving-the-plugin-agents-directory)).
+3. **Merge with local override.** Build one set of agents keyed by their
+   frontmatter `name`. A local `.claude/agents` file **OVERRIDES** a plugin
+   agent with the same `name` — the local file wins entirely; the plugin
+   version of that name is discarded (no field-level merge). Plugin agents whose
+   `name` is not shadowed locally are kept.
+4. **Validate phases.** For each merged agent that declares a `phase`: if its
+   `phase` value is **not** one of the 8 known hooks, **ignore** that agent
+   (it never runs) and **print a warning** naming the agent and its unknown
+   phase. Do not let an unknown phase match any hook.
+5. **Filter to this hook.** Keep only agents whose validated frontmatter
+   `phase` equals `HOOK`.
+6. **Empty check.** If the filtered set is empty, this is an **empty hook** —
+   return immediately. See [Empty-hook fast path](#empty-hook-fast-path).
+7. **Sort.** Sort the filtered agents by `order` ascending (a missing `order`
+   is treated as `100`), then by `name` for ties. See
+   [Sort and tie-break](#sort-and-tie-break).
+8. **Print the resolved order.** Before running anything, **PRINT** the
+   resolved, sorted list of agents (name, order, mode) for this hook so the run
+   is auditable.
+9. **Spawn.** Spawn each agent in the sorted order according to its `mode`:
+   - `single` → one subagent for the whole plan.
+   - `batch` → split the relevant file list into batches of ~10 and spawn
+     parallel subagents (one Task call per batch, all in a single message).
+
+### Resolving the plugin `agents/` directory
+
+Resolve the plugin's `agents/` directory **concretely** from the running
+skill's own file path. A skill lives at `skills/{name}/SKILL.md` inside the
+plugin, so the plugin root is **two levels up** from the skill file, and the
+agents directory is `{plugin-root}/agents/`. (This matches the convention used
+by `project-update`, which resolves the plugin dir as "two levels up from this
+skill file.")
+
+If the plugin `agents/` directory **cannot be resolved** from the skill path,
+fall back to using `.claude/agents` **only** (skip the plugin agents in steps 2
+and 3, and proceed with whatever local agents exist).
+
+### Empty-hook fast path
+
+A hook is **empty** when, after the local-overrides-plugin merge and the
+filter-to-this-hook step, **zero** agents have a `phase` equal to this hook.
+
+When a hook is empty:
+- **Return immediately.**
+- Perform **no logging and no narration.** This means more than suppressing the
+  resolved-order line: do **not** explain the empty result either. Do not state
+  which agents declared no `phase`, do not name the hook, do not say it is empty
+  or being skipped, and do not describe the enrollment analysis you just did.
+  The entire discovery routine for an empty hook is **silent and internal** —
+  nothing about it reaches the user-visible output.
+- Do **no work** — no staging, no diffing, no subagent spawns.
+
+This keeps unused hooks free of overhead and noise. The common failure mode is
+"thinking out loud" — narrating *why* a hook is empty (e.g. "standards-enforcer
+and tdd-worker declare no phase, so this hook is a no-op"). That narration is
+exactly what the fast path forbids: an empty hook is invisible, full stop. Only
+a **non-empty** hook produces visible output (its printed resolved order).
+
+### Sort and tie-break
+
+Order is fully deterministic:
+
+1. Sort by `order`, ascending (integer). A **missing** `order` is treated as
+   `100`.
+2. For agents with **equal** `order`, tie-break by `name`, **case-insensitive,
+   ascending** (A before B). For example, `Apple` and `banana` with the same
+   `order` sort as `Apple`, `banana`.
+
+## Legacy `pipeline.md`
+
+HCF no longer reads `pipeline.md` as configuration; frontmatter enrollment is
+always authoritative. A leftover `.claude/pipeline.md` is flagged by the
+`SessionStart` hook (`hooks/detect-legacy-pipeline.sh`) and, more importantly,
+**blocks the planning workflow**: `PreToolUse` (`gate-skill.sh`) and
+`UserPromptExpansion` (`gate-command.sh`) deny `plan-create`/`plan-orchestrate`
+while the file exists, regardless of how they are invoked. `/project-update` is
+left runnable — it is the only component that migrates or deletes the file, and
+once it does, the gates open automatically.

--- a/README.md
+++ b/README.md
@@ -111,69 +111,88 @@ ralph-wiggum is prompted during `/project-setup`, or install manually:
 |-------|------|--------------|
 | Setup | One-time | Configure project for autonomous dev |
 | Planning | Interactive | Discover codebase, brainstorm scope, then define tasks with human guidance |
-| Post-Plan Pipeline | Automated | Configurable agents review the plan |
-| Execution | Autonomous | Parallel TDD implementation + post-implementation pipeline |
+| Post-Plan Hooks | Automated | Agents enrolled at the `post-plan` hook review the plan |
+| Execution | Autonomous | Parallel TDD implementation, with agents enrolled at the implementation hooks |
 
 ### Pipeline
 
-The pipeline system controls which agents run before and after the core TDD implementation. It's configured in `.claude/pipeline.md`:
+The pipeline controls which agents run at fixed points in the plan/implementation flow. HCF uses **convention over configuration**: there is no central registry — each agent enrolls itself by declaring a `phase` in its own YAML frontmatter. If an agent declares a `phase`, it runs at that hook; if it has no `phase`, it never runs via a hook.
 
-```markdown
-# Pipeline
+**Hook points:**
 
-## post-plan
-- devils-advocate
+There are exactly **8** hook points where enrolled agents can run:
 
-## post-implementation
-<!-- - standards-enforcer -->
+| Hook | Fires |
+|------|-------|
+| `pre-plan` | Before planning Discovery begins |
+| `post-plan` | After the plan is built and validated, before user review |
+| `pre-implementation` | Before the first implementation batch |
+| `pre-batch` | Before each batch of TDD workers is spawned |
+| `post-batch` | After each batch of TDD workers completes |
+| `post-implementation` | After all tasks complete |
+| `pre-commit` | After the full test suite passes, before the commit |
+| `post-commit` | After the commit, before the push/PR prompt |
+
+By default, only `devils-advocate` is enrolled (at `post-plan`). See **[HOOKS.md](HOOKS.md)** for the authoritative reference — the full frontmatter schema, the deterministic discovery routine, and tie-break/ordering rules.
+
+**Enrollment frontmatter:**
+
+An agent enrolls by adding three keys to its frontmatter:
+
+```yaml
+---
+name: devils-advocate
+description: "..."
+model: opus
+tools: Read, Write, Edit, Glob, Grep
+# --- hook enrollment ---
+phase: post-plan   # one of the 8 hook points above
+order: 10          # lower runs first within a hook; default 100
+mode: single       # "single" | "batch"; default "single"
+---
 ```
-
-**Phases:**
-
-| Phase | When | Default Agent |
-|-------|------|---------------|
-| `post-plan` | After plan creation, before user review | `devils-advocate` |
-| `post-implementation` | After all TDD workers complete, before commit | none (`standards-enforcer` available, off by default) |
 
 **Customizing the pipeline:**
 
-Add, remove, or reorder agents at any phase. For example, to add a custom `security-reviewer` to post-plan, enable the built-in `standards-enforcer` (off by default), and add a custom `doc-updater` to post-implementation:
+Enable, add, remove, or reorder agents by editing frontmatter — never a central file.
 
-```markdown
-# Pipeline
+- **Enable a built-in agent.** `standards-enforcer` ships with its enrollment commented out. Uncomment its `phase` (and optional `order` / `mode`) to turn it on:
 
-## post-plan
-- devils-advocate
-- security-reviewer
+  ```yaml
+  ---
+  name: standards-enforcer
+  description: "..."
+  model: opus
+  tools: Read, Edit, Glob, Grep
+  # To enable code-standards enforcement after implementation, uncomment:
+  phase: post-implementation
+  order: 50
+  mode: batch
+  ---
+  ```
 
-## post-implementation
-- standards-enforcer
-- doc-updater
-```
+- **Add a custom gate.** Drop an agent file into your project's `.claude/agents/` directory with a `phase`, and it is enrolled automatically:
 
-**Creating custom agents:**
+  ```markdown
+  ---
+  name: doc-updater
+  description: "Updates documentation when implementation changes."
+  model: sonnet
+  tools: Read, Edit, Glob, Grep
+  phase: post-implementation
+  order: 100
+  mode: single
+  ---
 
-Create a markdown file in your project's `.claude/agents/` directory:
+  You are a documentation updater. Your job is to...
+  {define the agent's behavior, process, and output format}
+  ```
 
-```
-.claude/agents/doc-updater.md
-```
+- **Disable an agent.** Remove (or comment out) its `phase` key — there is no condition to toggle.
 
-The agent file follows the standard Claude Code agent format with frontmatter:
+The agent's **filename** (without `.md`) should match its frontmatter `name`. Local agents in `.claude/agents/` override plugin agents with the same `name` (the local file wins entirely).
 
-```markdown
----
-name: doc-updater
-description: "Updates documentation when implementation changes."
-model: sonnet
-tools: Read, Edit, Glob, Grep
----
-
-You are a documentation updater. Your job is to...
-{define the agent's behavior, process, and output format}
-```
-
-The agent name in `pipeline.md` must match the agent's filename (without `.md`). Local agents in `.claude/agents/` override plugin agents with the same name.
+> **Upgrading from `pipeline.md`:** Earlier versions of HCF configured the pipeline in a central `.claude/pipeline.md` file. That file is **no longer read** — agent frontmatter is now the only source of pipeline configuration. If a leftover `.claude/pipeline.md` is present, HCF **blocks `plan-create` and `plan-orchestrate`** (you'll see a prompt on session start and when you try to plan) until you run **`/project-update`**, which migrates your configuration into agent frontmatter and removes the file. `/project-update` is never blocked, and the gate clears automatically once the file is gone.
 
 ### Dependency Graph
 
@@ -225,7 +244,6 @@ Each task follows strict Red → Green → Refactor:
 | `testing.md` | Test commands, coverage requirements |
 | `code-standards.md` | Linting, formatting rules |
 | `architecture.md` | Directory structure, patterns |
-| `pipeline.md` | Workflow agent configuration |
 
 #### Plans (`.claude/plans/{name}/`)
 
@@ -293,7 +311,7 @@ hcf/
 │   │   └── SKILL.md          # Interactive planning skill (auto-triggers)
 │   └── plan-orchestrate/
 │       └── SKILL.md          # Parallel TDD execution skill (auto-triggers)
-├── pipeline.md               # Default pipeline configuration
+├── HOOKS.md                  # Authoritative hook/frontmatter reference
 ├── CLAUDE.md                 # Portable CLAUDE.md template for projects
 └── README.md
 ```

--- a/agents/devils-advocate.md
+++ b/agents/devils-advocate.md
@@ -3,6 +3,9 @@ name: devils-advocate
 description: "Devil's advocate architectural reviewer. Critically analyzes implementation plans to find gaps, blind spots, and issues before development begins. Auto-applies Critical and Important fixes to plan files."
 model: opus
 tools: Read, Write, Edit, Glob, Grep
+phase: post-plan
+order: 10
+mode: single
 ---
 
 # Devil's Advocate

--- a/agents/standards-enforcer.md
+++ b/agents/standards-enforcer.md
@@ -3,6 +3,10 @@ name: standards-enforcer
 description: "Code standards enforcement worker. Reviews and fixes a batch of files to match project coding standards without changing behavior."
 model: opus
 tools: Read, Edit, Glob, Grep
+# To enable code-standards enforcement after implementation, uncomment:
+# phase: post-implementation
+# order: 50
+# mode: batch
 ---
 
 You are a code standards enforcer. Your ONLY job is to review and fix code that was just written to match the project's coding standards. Do NOT add features, change behavior, or refactor logic.

--- a/hooks/detect-legacy-pipeline.sh
+++ b/hooks/detect-legacy-pipeline.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# HCF SessionStart hook — surfaces a legacy .claude/pipeline.md and urges migration.
+# Self-silences (exit 0, no output) when there is no legacy file, so it goes quiet
+# the moment /hcf:project-update removes the file. Enforcement of the block lives in the
+# PreToolUse / UserPromptExpansion gates; this hook is the up-front heads-up.
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$DIR/pipeline-status.sh"
+
+status="$(pipeline_status)"
+[ "$status" = "none" ] && exit 0
+
+if [ "$status" = "custom" ]; then
+  note="A legacy .claude/pipeline.md with CUSTOM pipeline configuration was found. HCF no longer reads it (agents enroll via frontmatter), so those customizations are currently INACTIVE. HCF planning is gated until you migrate: plan-create and plan-orchestrate are BLOCKED while this file exists. Strongly urge the user to run /hcf:project-update now (it is command-only, so they type it themselves) to migrate the customizations into agent frontmatter and remove the stale file. Surface this immediately, not as a passing note. Include this link so they can read about the change: https://github.com/markshust/hcf#pipeline"
+else
+  note="A legacy .claude/pipeline.md was found — a stale file from an older HCF version. HCF now enrolls agents via frontmatter and no longer reads it. HCF planning is gated until you migrate: plan-create and plan-orchestrate are BLOCKED while this file exists. Strongly urge the user to run /hcf:project-update now (it is command-only, so they type it themselves) to remove the stale file and bring the project onto the current model. Surface this immediately, not as a passing note. Include this link so they can read about the change: https://github.com/markshust/hcf#pipeline"
+fi
+
+printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"HCF migration required: %s"}}\n' "$note"

--- a/hooks/gate-command.sh
+++ b/hooks/gate-command.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# HCF UserPromptExpansion hook (matcher: plan-create|plan-orchestrate). Covers the
+# direct slash-command path (/plan-create, /plan-orchestrate) that PreToolUse does
+# NOT see. The matcher already scopes this to those commands, so we only need to
+# check for a legacy .claude/pipeline.md and block until it is migrated.
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$DIR/pipeline-status.sh"
+
+[ "$(pipeline_status)" = "none" ] && exit 0
+
+reason="HCF: this project still has a legacy .claude/pipeline.md. HCF now enrolls agents via frontmatter and no longer reads that file. Run /hcf:project-update first to migrate it into agent frontmatter and remove the stale file, then re-run this command. Share this link so they can read about the change: https://github.com/markshust/hcf#pipeline"
+printf '{"decision":"block","reason":"%s"}\n' "$reason"

--- a/hooks/gate-skill.sh
+++ b/hooks/gate-skill.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# HCF PreToolUse hook (matcher: Skill). Covers the path where Claude invokes the
+# Skill tool. Denies plan-create / plan-orchestrate while a legacy
+# .claude/pipeline.md exists, forcing migration via /hcf:project-update first.
+# Everything else (including /hcf:project-update itself) is left untouched.
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$DIR/pipeline-status.sh"
+
+input="$(cat)"
+
+# Only gate the HCF planning skills. project-update and all other skills pass through.
+case "$input" in
+  *plan-create*|*plan-orchestrate*) ;;
+  *) exit 0 ;;
+esac
+
+[ "$(pipeline_status)" = "none" ] && exit 0
+
+reason="HCF: this project still has a legacy .claude/pipeline.md. HCF now enrolls agents via frontmatter and no longer reads that file, so it must be migrated before the planning workflow can run. Tell the user to run /hcf:project-update first — it migrates any customizations into agent frontmatter and removes the stale file — then retry. Do not attempt to plan or orchestrate until the file is gone. Share this link so they can read about the change: https://github.com/markshust/hcf#pipeline"
+printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"%s"}}\n' "$reason"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,41 @@
+{
+  "description": "HCF lifecycle hooks. Detects a legacy .claude/pipeline.md and blocks the planning workflow (plan-create / plan-orchestrate) until it is migrated with /hcf:project-update.",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/detect-legacy-pipeline.sh",
+            "args": []
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/gate-skill.sh",
+            "args": []
+          }
+        ]
+      }
+    ],
+    "UserPromptExpansion": [
+      {
+        "matcher": "plan-create|plan-orchestrate",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/gate-command.sh",
+            "args": []
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/pipeline-status.sh
+++ b/hooks/pipeline-status.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Shared helper for HCF hooks. Classifies a project's legacy .claude/pipeline.md.
+# Sourced by the other hook scripts (no exec bit needed).
+#
+# pipeline_status echoes exactly one of:
+#   none    - no .claude/pipeline.md present
+#   default - present but only enrolls the shipped default (devils-advocate, or
+#             nothing active); frontmatter already reproduces it, so nothing is lost
+#   custom  - present with custom enrollment; those customizations are INACTIVE
+#             because HCF now enrolls agents via frontmatter
+
+pipeline_status() {
+  local project_dir pipeline names count
+  project_dir="${CLAUDE_PROJECT_DIR:-$PWD}"
+  pipeline="$project_dir/.claude/pipeline.md"
+
+  [ -f "$pipeline" ] || { echo none; return; }
+
+  # "Active" agents = non-commented "- name" bullets (HTML-commented lines inactive).
+  names="$(grep -E '^[[:space:]]*-[[:space:]]+[^[:space:]]' "$pipeline" 2>/dev/null \
+    | grep -v '<!--' \
+    | sed -E 's/^[[:space:]]*-[[:space:]]+//; s/[[:space:]].*$//')"
+  count="$(printf '%s\n' "$names" | grep -c '[^[:space:]]')"
+
+  if [ "$count" = "0" ] || { [ "$count" = "1" ] && printf '%s' "$names" | grep -qx 'devils-advocate'; }; then
+    echo default
+  else
+    echo custom
+  fi
+}

--- a/pipeline.md
+++ b/pipeline.md
@@ -1,8 +1,0 @@
-# Pipeline
-
-## post-plan
-- devils-advocate
-
-## post-implementation
-<!-- - standards-enforcer -->
-

--- a/skills/plan-create/SKILL.md
+++ b/skills/plan-create/SKILL.md
@@ -16,6 +16,27 @@ Transform feature requests into structured plans with task breakdowns, dependenc
 
 ## Execution Flow
 
+### Phase 0: Pre-plan hook
+
+Run this once, at the very start, before Phase 1 discovery.
+
+**Run the `pre-plan` hook.**
+
+Resolve and run agents enrolled at the `pre-plan` hook using the `HOOKS.md` Discovery Routine (glob local `.claude/agents/*.md`, glob the plugin `agents/` directory resolved **two levels up from this `SKILL.md`** per HOOKS.md, merge with local override, validate phases, filter to `pre-plan`, sort by `order` then `name`). This hook is **empty by default** — if no agent declares `phase: pre-plan`, take the empty-hook fast path: return immediately, print nothing, spawn nothing, and proceed to Phase 1.
+
+If the hook is non-empty, **print the resolved agent order** (name, order, mode) before spawning, then spawn each agent in order per its `mode`.
+
+**IMPORTANT — no plan name exists yet.** The `pre-plan` hook fires *before* Phase 1 discovery. The plan name and plan directory are not created until Phase 3, so there is **no plan name to pass**. Each `pre-plan` agent receives only:
+1. The raw feature request (the user's verbatim ask).
+2. The project's architecture context:
+
+```
+## Project Architecture
+{paste the COMPLETE content of <architecture> verbatim}
+```
+
+Do **not** attempt to pass a plan name or plan directory to a `pre-plan` agent — neither exists yet. The `pre-plan` hook is thin by design (policy gate / house-context injection).
+
 ### Phase 1: Discovery & Assumption Brainstorm
 
 Approach this phase like a solution architect meeting with a client to flush out scope and requirements. Your job is not to ask everything — it's to think hard about the shape of the solution before asking grounded questions. Find the integration points, then enumerate the design axes the user probably hasn't thought about.
@@ -222,40 +243,40 @@ Show the user a simple dependency tree:
      └─► 004 ────► 006
 ```
 
-### Phase 6: Run Post-Plan Pipeline
+### Phase 6: Run the `post-plan` Hook
 
-After validating dependencies, run all agents configured in the `post-plan` phase of `pipeline.md`.
+After validating dependencies, resolve and run the agents enrolled at the `post-plan` hook.
 
-**1. Read the pipeline configuration:**
+**1. Discover `post-plan` agents via frontmatter.**
 
-Parse the `## post-plan` section from the `<pipeline>` context included in CLAUDE.md. Each bullet point is an agent name to spawn.
+Resolve which agents run using the `HOOKS.md` Discovery Routine. Concretely: glob local `.claude/agents/*.md`, glob the plugin `agents/` directory (resolved **two levels up from this `SKILL.md`** per HOOKS.md), merge with local override, validate phases, filter to agents whose frontmatter `phase` equals `post-plan`, then sort by `order` ascending (missing `order` = `100`), tie-broken by case-insensitive `name`.
 
-**2. For each agent in the post-plan list**, spawn it sequentially:
+**2. Empty-hook fast path.**
 
-Use the Agent tool with `subagent_type="{agent-name}"` and pass the plan name and project context.
+If the filtered set is empty, this is an empty hook: **return immediately** — print nothing, spawn nothing, do no work — and proceed to Phase 7. (No agent declaring `phase: post-plan` is a valid, clean configuration.)
 
-**The subagent prompt must include:**
-1. The plan name (so it knows the directory path)
-2. The project's architecture context:
+**3. Print the resolved agent order.**
+
+If the hook is non-empty, **PRINT** the resolved, sorted list of `post-plan` agents (name, order, mode) before spawning anything, so the run is auditable.
+
+**4. Spawn each agent in the resolved order**, sequentially:
+
+Use the Agent tool with `subagent_type="{agent-name}"`. The subagent prompt **must** include:
+1. The plan name (so it knows the plan directory path).
+2. The project's architecture context, pasted verbatim — do **not** summarize:
 
 ```
 ## Project Architecture
 {paste the COMPLETE content of <architecture> verbatim}
 ```
 
-**3. After each subagent completes**, read any updated plan files to prepare the recap for the user.
+**5. After each subagent completes**, read any updated plan files to prepare the recap for the user.
 
-**Default pipeline** (ships with HCF):
-```
-## post-plan
-- devils-advocate
-```
-
-Users can add, remove, or reorder agents in their project's `.claude/pipeline.md`. For example, adding a `security-reviewer` agent after `devils-advocate`.
+Agents enroll in `post-plan` by declaring `phase: post-plan` in their own frontmatter (see `HOOKS.md`). There is no hardcoded default list here — for example, `devils-advocate` participates because it declares `phase: post-plan` in its frontmatter, not because plan-create names it. To add, remove, or reorder agents at this hook, edit their frontmatter `phase`/`order` (or override a plugin agent with a local `.claude/agents` file of the same `name`).
 
 ### Phase 7: Review with User
 
-Present the refined plan along with what the devil's advocate changed:
+Present the refined plan along with a summary of whatever `post-plan` agents actually ran in Phase 6.
 
 > Here's the plan I've created for **{feature name}**:
 >
@@ -267,12 +288,14 @@ Present the refined plan along with what the devil's advocate changed:
 > | 001 | {title} | none |
 > | 002 | {title} | 001 |
 > | ... | ... | ... |
+
+**If one or more `post-plan` agents ran**, include a review section that summarizes what *those specific agents* changed. Title it after the agents that ran (e.g. "Post-Plan Review by {agent names that ran}"), and attribute the changes to the agent that made them. Do **not** assume a single fixed reviewer or hardcode "devil's advocate" — render whatever the resolved Phase 6 hook produced:
+
+> **Post-Plan Review** ({names of agents that ran})
 >
-> **Post-Plan Review**
+> The plan was reviewed by the agents enrolled at the `post-plan` hook. Here's what each refined:
 >
-> The plan was automatically reviewed by the post-plan pipeline agents. Here's what was refined:
->
-> {summarize changes from each agent that ran, e.g.:}
+> {for each agent that ran, summarize its changes, e.g.:}
 > - Added missing dependency: task 005 now depends on 003 (shared interface needed)
 > - Split task 008 into 008 and 009 (too large for single TDD cycle)
 > - Added edge case requirements to task 004 (empty state handling)
@@ -281,7 +304,11 @@ Present the refined plan along with what the devil's advocate changed:
 > {if there are deferred items from any agent, list them:}
 > **Items for your consideration:**
 > - {Items the user may want to weigh in on}
->
+
+**If no `post-plan` agents ran** (the hook was empty), omit the "Post-Plan Review" section entirely — do not print an empty heading or any "reviewed by" line. Present the plan table and go straight to the approval prompt below.
+
+Then, in all cases, ask:
+
 > Does this breakdown look correct? Would you like to:
 > 1. Approve and proceed
 > 2. Add/remove tasks

--- a/skills/plan-orchestrate/SKILL.md
+++ b/skills/plan-orchestrate/SKILL.md
@@ -105,6 +105,19 @@ If plan status is `ready`, change to `in_progress`:
 - Edit `.claude/plans/{plan-name}/_plan.md`
 - Set `## Status` to `in_progress`
 
+### Step 2a: Pre-Implementation Hook
+
+Run the `pre-implementation` hook **once**, after the status is set to
+`in_progress` and **before** the first batch is spawned.
+
+Resolve and run enrolled agents via the **HOOKS.md discovery routine** (see
+[Hook Discovery](#hook-discovery) below) with `HOOK = pre-implementation`. Pass
+each agent the project context as described in
+[Spawning hook agents](#spawning-hook-agents).
+
+If the hook is **empty** (no enrolled agents), honor the **empty-hook fast
+no-op**: return immediately, log nothing, do no work, and proceed to Step 3.
+
 ### Step 3: Find Ready Tasks
 
 A task is **ready** when:
@@ -124,7 +137,7 @@ for each task in tasks:
 **All Complete:**
 ```
 if all(task.status == "completed" for task in tasks):
-    Run Step 4a: Post-Implementation Pipeline (quality gates before final completion)
+    Run Step 4a: End-of-Run Hooks (quality gates + commit sequence before final completion)
     STOP
 ```
 
@@ -138,37 +151,55 @@ if len(ready_tasks) == 0:
         STOP
 ```
 
-### Step 4a: Post-Implementation Pipeline
+## Hook Discovery
 
-When all tasks are complete, run the agents configured in the `post-implementation` phase of `pipeline.md`.
+All hooks in this skill (`pre-implementation`, `pre-batch`, `post-batch`,
+`post-implementation`, `pre-commit`, `post-commit`) resolve their enrolled
+agents through the **single, authoritative discovery routine defined in
+[HOOKS.md → Discovery Routine](../../HOOKS.md#discovery-routine)**. Follow that
+routine literally; do not duplicate or improvise it here. In summary, for a
+given `HOOK`:
 
-**1. Read the pipeline configuration:**
+- Glob `.claude/agents/*.md` (local) and the **plugin** `agents/*.md`, with
+  local files overriding plugin agents of the same `name`.
+- **Resolve the plugin `agents/` directory** exactly as HOOKS.md /
+  `project-update` does: it is **two levels up from this `SKILL.md`** (this file
+  lives at `skills/plan-orchestrate/SKILL.md`, so the plugin root is two levels
+  up and the agents directory is `{plugin-root}/agents/`). If it cannot be
+  resolved from the skill path, fall back to `.claude/agents` only.
+- Enrollment is **purely frontmatter-based**: every agent declares its `phase`
+  in frontmatter, so frontmatter is always authoritative. There is no other
+  source to consult or merge.
+- Validate phases, **filter to this `HOOK`**, and sort by `order` ascending then
+  `name` (case-insensitive) for ties.
+- **Empty-hook fast no-op:** if the filtered set is empty, **return
+  immediately** — no staging, no diffing, no spawns, and **no logging or
+  narration**. "No narration" is literal and is the rule most often broken: do
+  not name the hook, do not say it is empty/skipped, and do not explain *why*
+  it is empty (e.g. "tdd-worker and standards-enforcer declare no phase, so this
+  is a no-op"). An empty hook is **completely invisible** in the user-facing
+  output — resolve it silently and move on. See [HOOKS.md → Empty-hook fast
+  path](../../HOOKS.md#empty-hook-fast-path).
+- Otherwise, **PRINT the resolved order** (each agent's `name`, `order`, `mode`)
+  before spawning anything, then spawn each agent per its **`mode` field**
+  (`single` → one subagent for the whole plan; `batch` → split the relevant file
+  list into batches of ~10 and spawn parallel subagents, one Task call per
+  batch, all in a single message). The spawn mode comes from the agent's `mode`
+  frontmatter field — never from sniffing the agent body text.
 
-Parse the `## post-implementation` section from the `<pipeline>` context included in CLAUDE.md. Each bullet point is an agent name to run.
+### Spawning hook agents
 
-**2. Get the list of changed files:**
-```bash
-git add -A && git diff --name-only --cached && git reset HEAD
-```
-This temporarily stages everything to get the file list, then unstages. Nothing is committed yet.
+Hook agents are spawned with the Task tool using `subagent_type="{agent-name}"`.
+The orchestrator only has `<testing>` and `<code-standards>` in context (see
+[Project Configuration](#project-configuration)) — it does NOT have
+`<architecture>`. Pass each hook agent the project context it needs verbatim:
 
-**3. For each agent in the post-implementation list**, run it with the changed files:
+> **CRITICAL: Pass the COMPLETE, VERBATIM content of the `<code-standards>` and
+> `<testing>` tags above. Do NOT summarize, condense, or paraphrase. The full
+> documents contain nuanced rules that are lost when summarized. Copy-paste the
+> entire content between the tags.**
 
-For agents that operate on file batches (like `standards-enforcer`), split files into batches of ~10 and spawn parallel subagents. For agents that operate on the plan as a whole, spawn a single subagent.
-
-**How to determine the agent's mode:** Read the agent's `.md` file. If it references "batch" or "file list" in its prompt format, use batch mode. Otherwise, use single mode.
-
-**Batch mode** (e.g., standards-enforcer):
-```
-Use the Task tool with subagent_type="{agent-name}" for EACH batch.
-All Task tool calls MUST be made in a SINGLE message to enable parallel execution.
-```
-
-Worker Prompt (per batch):
-
-> **CRITICAL: Pass the COMPLETE, VERBATIM content of the `<code-standards>` and `<testing>` tags above.
-> Do NOT summarize, condense, or paraphrase. The full documents contain nuanced rules
-> that are lost when summarized. Copy-paste the entire content between the tags.**
+For a **`batch`** agent, send one prompt per batch:
 
 ```markdown
 ## Code Standards
@@ -181,14 +212,42 @@ Worker Prompt (per batch):
 {list of files in this batch, one per line}
 ```
 
-**Single mode** (e.g., doc-updater):
-```
-Use the Task tool with subagent_type="{agent-name}" once.
+For a **`single`** agent, send one prompt covering the whole plan, including the
+plan name, the changed-files list, and `<testing>` + `<code-standards>` verbatim.
+
+> If a hook agent needs project architecture, that is out of scope for this
+> orchestrator — it does not load `<architecture>`. Do NOT fabricate an
+> `## Project Architecture` paste here.
+
+### Step 4a: End-of-Run Hooks (Post-Implementation → Tests → Commit)
+
+When all tasks are complete, run the end-of-run hook sequence. The control flow
+is strictly:
+
+**post-implementation → run full test suite → pre-commit → commit → post-commit**
+
+> **CRITICAL INVARIANT: NOTHING is committed until AFTER the full test suite
+> passes.** This ensures no broken code is ever committed. The `pre-commit` hook
+> runs *after* tests pass and *before* the commit; `post-commit` runs *after*
+> the commit and *before* the push/PR prompt.
+
+**1. Run the `post-implementation` hook:**
+
+Resolve and run enrolled agents via the [Hook Discovery](#hook-discovery)
+routine with `HOOK = post-implementation`. To give batch agents a file list,
+first compute the changed files (this stages everything only to read the list,
+then unstages — nothing is committed):
+
+```bash
+git add -A && git diff --name-only --cached && git reset HEAD
 ```
 
-Pass the plan name, changed files list, and any relevant project context.
+Then spawn the resolved agents per their `mode` (see
+[Spawning hook agents](#spawning-hook-agents)). If the hook is **empty**, honor
+the **empty-hook fast no-op** (return immediately, no logging, no work) and
+proceed to step 2.
 
-**4. After ALL post-implementation agents complete, run validation:**
+**2. After ALL post-implementation agents complete, run validation:**
 ```bash
 # Run full test suite
 {parallel test command from testing.md}
@@ -196,36 +255,77 @@ Pass the plan name, changed files list, and any relevant project context.
 
 > **CRITICAL: Nothing is committed until AFTER the full test suite passes.** This ensures no broken code is ever committed.
 
-**5. On tests passing:**
+**3. On test failure** — isolate the cause (see
+[Test-failure isolation](#test-failure-isolation) below), then either commit the
+implementation only or output `TASKS_BLOCKED`.
+
+**4. On tests passing — run the `pre-commit` hook:**
+
+Resolve and run enrolled agents via [Hook Discovery](#hook-discovery) with
+`HOOK = pre-commit`. These run *after* the suite passes and *before* the commit.
+Honor the **empty-hook fast no-op**.
+
+> If a `pre-commit` agent modifies files, those edits are part of this commit. A
+> pre-commit agent that changes files could break tests; that risk is covered by
+> the [Test-failure isolation](#test-failure-isolation) stash, which now spans
+> both post-implementation and pre-commit hook output.
+
+**5. Commit:**
 First, update `_plan.md` status to `completed`. Then stage and commit everything together in a **single commit**:
 ```bash
 # 1. Update plan status BEFORE committing
 # (edit .claude/plans/{plan-name}/_plan.md — set Status to "completed")
 
-# 2. Stage everything: implementation + pipeline agent fixes + plan files (including updated status)
+# 2. Stage everything: implementation + hook agent fixes + plan files (including updated status)
 git add -A .claude/plans/{plan-name}/
 git add -A
 git commit -m "feat({plan-name}): {plan title summary}"
 ```
 > **IMPORTANT:** There must be exactly ONE commit here — do NOT make a separate commit for the plan status update. Update the status first, then stage and commit all changes together.
 
+**6. After the commit succeeds — run the `post-commit` hook:**
+
+Resolve and run enrolled agents via [Hook Discovery](#hook-discovery) with
+`HOOK = post-commit`. These run *after* the commit and *before* the push/PR
+prompt (the [Output Summary](#output-summary) at the end of this skill). Honor
+the **empty-hook fast no-op**.
+
+> **`post-commit` agents that produce uncommitted changes are REPORTED, not
+> silently committed.** The commit above already happened; do not amend or
+> create a second commit. Surface any working-tree changes a post-commit agent
+> left behind so the user can decide what to do.
+
 Output: `ALL_TASKS_COMPLETE`
 
-**6. On test failure:**
-- Revert only the post-implementation agent changes to isolate whether they broke things:
-   ```bash
-   git stash
-   ```
-   Re-run the test suite on just the implementation.
-- If implementation tests pass: a post-implementation agent broke something. Drop the stash, commit implementation only, and output:
+#### Test-failure isolation
+
+If the full test suite fails at step 3 (or after pre-commit edits), isolate
+whether the **hook agents** (any `post-implementation` or `pre-commit` agent
+that edited files) broke things versus the implementation itself. The git stash
+isolation spans **both** the post-implementation and pre-commit hook output:
+
+```bash
+git stash
+```
+Re-run the test suite on just the implementation.
+
+- If implementation tests pass: a hook agent (post-implementation or pre-commit)
+  broke something. Drop the stash, commit implementation only, and output:
    ```
    ALL_TASKS_COMPLETE
 
-   WARNING: Post-implementation pipeline broke tests. Implementation committed without pipeline fixes. Review and run manually.
+   WARNING: A post-implementation or pre-commit hook agent broke tests. Implementation committed without hook fixes. Review and run manually.
    ```
-- If implementation tests also fail: a TDD worker produced broken code. Restore the stash (`git stash pop`) and output `TASKS_BLOCKED` with details.
+- If implementation tests also fail: a TDD worker produced broken code. Restore
+  the stash (`git stash pop`) and output `TASKS_BLOCKED` with details.
 
 ### Step 5: Spawn Parallel Workers
+
+**Pre-batch hook (this loop iteration).** Before spawning workers, run the
+`pre-batch` hook via the [Hook Discovery](#hook-discovery) routine with
+`HOOK = pre-batch`. Because this runs on **every** loop iteration, honoring the
+**empty-hook fast no-op** is important: if no agents are enrolled, return
+immediately — log nothing, do no work — so unconfigured loops add zero overhead.
 
 For EACH ready task, spawn a Task tool subagent **in parallel** (single message with multiple Task tool calls):
 
@@ -272,6 +372,13 @@ Wait for ALL parallel Task tool calls to complete. For each result:
 3. If retry count < 3:
    - Keep status as `pending` (will retry in next batch)
    - Log the failure for visibility
+
+**Post-batch hook (this loop iteration).** After all results for this batch are
+collected and statuses are updated, run the `post-batch` hook via the
+[Hook Discovery](#hook-discovery) routine with `HOOK = post-batch`. Because this
+runs on **every** loop iteration, honoring the **empty-hook fast no-op** is
+important: if no agents are enrolled, return immediately — log nothing, do no
+work — so unconfigured loops add zero overhead.
 
 ### Step 7: Report Progress
 
@@ -339,7 +446,7 @@ ALL_TASKS_COMPLETE
 Plan: {plan-name}
 Total tasks: {N}
 All tests passing.
-Post-implementation pipeline complete.
+Post-implementation hooks complete.
 Commits created: {N}
 
 ## What Changed

--- a/skills/project-setup/SKILL.md
+++ b/skills/project-setup/SKILL.md
@@ -17,10 +17,10 @@ Create `CLAUDE.md` and all project configuration files in `.claude/` through an 
 First, check if configuration already exists:
 
 ```bash
-ls CLAUDE.md .claude/testing.md .claude/code-standards.md .claude/architecture.md .claude/pipeline.md 2>/dev/null
+ls CLAUDE.md .claude/testing.md .claude/code-standards.md .claude/architecture.md 2>/dev/null
 ```
 
-If CLAUDE.md and all 4 config files exist, inform the user:
+If CLAUDE.md and all 3 config files (`testing.md`, `code-standards.md`, `architecture.md`) exist, inform the user:
 > Project already configured. CLAUDE.md and config files exist in `.claude/`. To reconfigure, delete CLAUDE.md and `.claude/` then run `/project-setup` again.
 
 Otherwise, continue with setup.
@@ -264,26 +264,13 @@ Example:
 
 *Optional expansions: DI/IoC details, plugin/extension system, event system, routing, configuration, bootstrap process, error handling, versioning strategy.*
 
-**Create `.claude/pipeline.md`:**
+**Pipeline enrollment (nothing to scaffold):**
 
-Copy the default `pipeline.md` from the HCF plugin into the project's `.claude/` directory. This defines which agents run at each phase of the workflow.
-
-```markdown
-# Pipeline
-
-Configure which agents run at each phase of the development workflow. Each entry is an agent name resolved from the project's `.claude/agents/` directory (local override) or the plugin's `agents/` directory (default).
-
-## post-plan
-- devils-advocate
-
-## post-implementation
-<!-- - standards-enforcer -->
-```
+Pipeline agents enroll via their own frontmatter (`phase:`), so a fresh setup already has a working pipeline from the plugin's bundled agents — nothing to scaffold here. `devils-advocate` runs at `post-plan`; `standards-enforcer` ships dormant (uncomment its `phase` to enable). See `HOOKS.md`.
 
 Tell the user:
-> **Pipeline configured** with `devils-advocate` enabled in `post-plan`. The `post-implementation` phase has `standards-enforcer` available but commented out by default — uncomment in `.claude/pipeline.md` if you want code-standards enforcement to run on changed files before commit.
-> You can customize `.claude/pipeline.md` to add, remove, or reorder agents at each phase.
-> Custom agents go in `.claude/agents/` — see the HCF README for details.
+> **Pipeline ready.** `devils-advocate` is enrolled at the `post-plan` hook via its own agent frontmatter, so it runs automatically when you create a plan. `standards-enforcer` ships with HCF but is dormant — uncomment its `phase` key in the agent's frontmatter to enable code-standards enforcement on changed files.
+> To add your own gate, drop an agent file in `.claude/agents/` and give it a `phase` (one of the 8 hook points). A local agent with the same `name` overrides the plugin's. See `HOOKS.md` for the full hook list and frontmatter schema.
 
 **Create `CLAUDE.md` in project root:**
 
@@ -293,6 +280,14 @@ This file provides always-on context for every Claude session. Keep it concise (
 # {Project Name}
 
 {Brief 1-2 sentence description of the project.}
+
+## Feature Development
+
+For any feature or change beyond a simple fix, use the `hcf:plan-create` skill to trigger the autonomous development workflow. Never use Claude Code's built-in plan mode. After writing a plan, ask the user if they want to execute it, and provide the command to run it later with the `hcf:plan-orchestrate` skill.
+
+Use this workflow for: new features, multi-file changes, anything requiring multiple steps or tests.
+
+Skip for: quick bug fixes, single-line changes, questions, documentation. When skipped, still ensure appropriate tests exist for any added functionality.
 
 ## Tech Stack
 
@@ -371,14 +366,13 @@ After creating all files, output:
 ✓ Created .claude/testing.md
 ✓ Created .claude/code-standards.md
 ✓ Created .claude/architecture.md
-✓ Created .claude/pipeline.md
 {✓ Installed ralph-wiggum plugin (if installed)}
 
 Project configured for autonomous development!
 
 Next steps:
 1. Review CLAUDE.md and the generated files in .claude/
-2. Customize .claude/pipeline.md to add/remove workflow agents
+2. Customize the pipeline by enrolling agents via frontmatter — set a `phase` on an agent in .claude/agents/ to add a gate, or remove a `phase` to drop one (see HOOKS.md)
 3. Describe a feature to start planning: "Help me implement..."
 4. The plan-create skill will auto-trigger to help you plan
 ```

--- a/skills/project-update/SKILL.md
+++ b/skills/project-update/SKILL.md
@@ -33,21 +33,67 @@ These are the files that `project-setup` creates. Check which exist:
 | `.claude/testing.md` | Generated from project context |
 | `.claude/code-standards.md` | Generated from project context |
 | `.claude/architecture.md` | Generated from project context |
-| `.claude/pipeline.md` | Copied from plugin's `pipeline.md` |
+
+> `.claude/pipeline.md` is **legacy** and is no longer an expected ongoing file. HCF now enrolls agents via frontmatter (see [HOOKS.md](../../HOOKS.md)). If a `.claude/pipeline.md` exists, it is handled by the one-time migration in Step 3 — do not treat its absence as a missing file.
 
 Collect the list of missing files. Do NOT act on them yet — just note them.
 
-### Step 3: Compare Plugin-Sourced Files
+### Step 3: Migrate Legacy `pipeline.md` to Frontmatter
 
-For files that originate from the plugin (currently `pipeline.md`), compare the project's version against the plugin's default:
+This is a **one-time migration** from the legacy central registry (`.claude/pipeline.md`) to per-agent frontmatter enrollment (the model described in [HOOKS.md](../../HOOKS.md)). This step **detects** what needs to happen here; the actual changes are applied in Step 7 after a single confirmation.
 
-1. Read the plugin's default `pipeline.md` (from the plugin directory — resolve via the skill's own path, i.e., two levels up from this skill file)
-2. Read the project's `.claude/pipeline.md` (if it exists)
-3. Parse both to extract the list of agents per phase
+#### 3a. Detect the legacy file
 
-**For each phase in the plugin's default:**
-- If the phase doesn't exist in the project's pipeline, note that a new phase is available
-- If the phase exists but is missing default agents, note which default agents are new
+Check whether `.claude/pipeline.md` exists:
+
+```bash
+ls .claude/pipeline.md 2>/dev/null
+```
+
+- **Absent** → the project is already on the frontmatter model. Record migration status as *"no legacy `pipeline.md` — already on frontmatter"* and **skip the rest of Step 3 entirely**. There is nothing to migrate.
+- **Present** → continue to 3b.
+
+#### 3b. Compare against the known default
+
+The migrator **must not** read the plugin's `pipeline.md` for comparison — that file is being removed from the plugin and will no longer exist. The known shipped default is embedded inline here:
+
+```markdown
+# Pipeline
+
+## post-plan
+- devils-advocate
+
+## post-implementation
+<!-- - standards-enforcer -->
+```
+
+Structurally, the default means: **`devils-advocate` is the only active agent** (under `post-plan`), and `post-implementation` has only a commented-out `standards-enforcer` (no active agents).
+
+Read the project's `.claude/pipeline.md` and parse it into `(phase heading → [active agent names])`, where an "active" agent is a non-commented `- {name}` bullet under a `## {phase}` heading. Commented lines (`<!-- ... -->`) are NOT active agents.
+
+- **Matches the default** (the only active agent across all phases is `devils-advocate` under `post-plan`, and nothing else is active) → migration is a **no-op delete**: the shipped frontmatter (`devils-advocate` with `phase: post-plan`) already reproduces it, so no agent needs stamping. Record migration status as *"legacy `pipeline.md` found (unchanged default) — will delete; frontmatter already reproduces it"*.
+- **Customized** (any active agent other than the default `devils-advocate`/`post-plan` arrangement — e.g. an extra agent, a reordering, a different phase, or an uncommented `standards-enforcer`) → record migration status as *"legacy `pipeline.md` found (customized) — will migrate its active entries to frontmatter (preserving what runs) and delete it"*, and compute the per-agent migration plan in 3c (which skips agents the plugin already enrolls, stamps local agents in place, and copies + enables any plugin agent the project had turned on).
+
+#### 3c. Build the per-agent migration plan (customized pipelines only)
+
+Parse every `## {phase}` heading and, **in listed order**, every active `- {name}` agent bullet beneath it.
+
+**Guiding principle: migration is behavior-preserving.** Whatever was *active* in `pipeline.md` must remain active under the new frontmatter model — the project's effective pipeline does not change. A local file is created **only when it is needed to reproduce an enrollment the plugin default does not already provide**: that way we never leave a redundant shadow, but we also never silently disable something the project was running.
+
+For each `(phase, position, name)`, resolve the agent against both `.claude/agents/{name}.md` (local) and `{plugin-root}/agents/{name}.md` (plugin — resolve the plugin dir two levels up from this skill file), then classify by what it takes to keep the agent enrolled at this `phase`:
+
+1. **Already enrolled by the plugin at this same phase** — no differing local copy, and the current plugin's `agents/{name}.md` already declares this `phase` (e.g. `devils-advocate` under `post-plan`). → **Skip entirely — no file.** The plugin already runs it here; a copy would be a redundant shadow. Record as *"already provided by the plugin — no action"*.
+2. **Genuinely local / locally-modified agent** — a local `.claude/agents/{name}.md` exists and either has no plugin counterpart or its **body differs** from the plugin's. → **Stamp it in place** with `phase`/`order`/`mode`. No copy (already local).
+3. **Plugin agent the project ENABLED but the plugin ships off / elsewhere** — no differing local copy, and the plugin does NOT declare this `phase` (e.g. an uncommented `standards-enforcer` under `post-implementation`, which the plugin ships dormant). The project was actively running it, so migration must **preserve that**: **copy the plugin's `agents/{name}.md` into `.claude/agents/{name}.md` and stamp** `phase`/`order`/`mode`. This is the *only* mechanism to keep a dormant plugin agent enabled, and it is required here — without it the migration would silently disable a capability the project was using. (The plugin ships such agents with their `phase` **commented out**; the stamp must write **active** `phase`/`order`/`mode` keys, replacing any commented enable-example carried over in the copy, so the agent is actually enabled.) (Note in the report: this local copy will not receive future plugin updates to that agent's body — the inherent cost of enabling a dormant plugin agent.)
+4. **Unresolvable** — no local file and no plugin file by that name. → A dangling legacy reference; record as a ⚠ for the user. Do not fabricate a file.
+
+**Frontmatter to stamp** (cases 2 and 3):
+   - `phase`: the `## {phase}` heading the agent is listed under.
+   - `order`: the agent's **1-based listed position within that phase × 10** (first → `10`, second → `20`, …).
+   - `mode`: apply the **legacy body heuristic exactly once, here** (its last use ever): read the agent's **body** — if it mentions operating in **"batch"** or over a **"file list"**, stamp `mode: batch`; otherwise `mode: single`.
+   - No `on-failure` or any other field — the schema (HOOKS.md) defines only `phase`, `order`, `mode`.
+
+Record this plan; it is applied in Step 7. **Never change what the project runs:** an agent already enrolled by the plugin is left alone; a genuinely-local agent is stamped; a plugin agent the project had enabled is copied + stamped so it keeps running; a dangling reference is reported. The end state reproduces the project's effective pre-migration pipeline exactly.
 
 ### Step 4: Check .gitignore Entries
 
@@ -61,7 +107,11 @@ For each missing entry, append it to `.gitignore`.
 
 ### Step 5: Check CLAUDE.md References
 
-Read the project's `CLAUDE.md` and verify it references the `.claude/` config files: `testing.md`, `code-standards.md`, and `architecture.md`. Skip `pipeline.md` — it's consumed internally by the HCF plugin, not by Claude directly.
+Read the project's `CLAUDE.md` and verify it references the `.claude/` config files: `testing.md`, `code-standards.md`, and `architecture.md`.
+
+Also check whether `CLAUDE.md` contains a **Feature Development section** that wires up the planning workflow. Detect it by searching for a mention of the `hcf:plan-create` skill (a project may title the section differently, so match on the skill reference, not the heading text). If no reference to `plan-create` exists anywhere in `CLAUDE.md`, the section is **missing** — flag it for **automatic addition** in Step 7. This matters because without it `CLAUDE.md` never tells Claude to route feature work through HCF, and a strongly-worded "do this instead" elsewhere in `CLAUDE.md` (e.g. "start from this checklist") can suppress the skill's auto-trigger. If a `plan-create` reference already exists, record it as ✓ and do not touch it (the project may have customized the wording).
+
+Also scan `CLAUDE.md` for any **stale reference to `pipeline.md`** — either the `<pipeline>` include block, or a config-file bullet/link an older `project-setup` left behind (e.g. `` - `pipeline.md` - Autonomous development workflow agents `` under a "Files" / "Detailed Configuration" section). `pipeline.md` is legacy and no longer read, so any such reference must go. Flag every stale reference for **automatic removal** in Step 7. This is independent of the Step 3 migration: a project that already migrated (so `pipeline.md` is gone) can still carry a stale reference, and this run must clean it.
 
 Note any missing references.
 
@@ -77,11 +127,11 @@ Files:
   ✓ .claude/testing.md — exists
   ✓ .claude/code-standards.md — exists
   ✓ .claude/architecture.md — exists
-  ✓ .claude/pipeline.md — exists (customized)
 
-Pipeline:
-  ✓ post-plan phase — up to date
-  ⚠ post-implementation phase — plugin default includes 'standards-enforcer', project pipeline does not (intentional?)
+Pipeline migration:
+  ⚠ legacy .claude/pipeline.md found (customized) — will migrate active entries to frontmatter (preserving what runs) and delete it:
+      • devils-advocate    (post-plan)          → already provided by the plugin; no action
+      • standards-enforcer (post-implementation) → enabled via frontmatter (copied into .claude/agents/ so it keeps running; won't auto-update with the plugin)
 
 .gitignore:
   ✓ .claude/ralph-loop.local.md — present
@@ -90,12 +140,28 @@ CLAUDE.md References:
   ✓ testing.md — referenced
   ✓ code-standards.md — referenced
   ✓ architecture.md — referenced
+  ✗ Feature Development section — missing; will add automatically (wires up hcf:plan-create / plan-orchestrate)
+  ⚠ pipeline.md — stale reference(s) found; will remove automatically (legacy, no longer read)
 ```
 
-If there are any ✗ or ⚠ items, ask the user:
-> I found {N} items that need attention. Want me to fix them? I'll walk you through each one.
+The `✗ Feature Development section — missing` line appears only when `CLAUDE.md` has no reference to `hcf:plan-create`. It is added automatically in Step 7 (purely additive — a new section, no existing content is changed). Omit the line when a `plan-create` reference already exists.
 
-If the user confirms, proceed to Step 7. If everything is current, output "All up to date!" and stop.
+The `⚠ pipeline.md — stale reference(s) found` line appears only when `CLAUDE.md` still references the legacy file (the `<pipeline>` include and/or a config-file bullet). Those are scrubbed automatically in Step 7 — independent of any migration, so this line can appear even for a project that already migrated. Omit the line when there are no such references.
+
+The **Pipeline migration** line reflects the Step 3 detection and is one of:
+
+- *no legacy `.claude/pipeline.md` — already on frontmatter* (✓; nothing to do)
+- *legacy `.claude/pipeline.md` found (unchanged default) — will delete; frontmatter already reproduces it* (⚠ no-op delete)
+- *legacy `.claude/pipeline.md` found (customized) — will migrate active entries to frontmatter (preserving what runs) and delete it* (⚠; list each active agent with its 3c outcome: **already provided by the plugin** (skipped, no file), **stamped** in place (local/modified agents), or **enabled via a local copy** (a plugin agent the project had turned on that the plugin ships dormant).)
+
+When a customized `pipeline.md` is present, also include this note so the situation is explicit:
+
+> Note: HCF no longer reads `.claude/pipeline.md` at all — agents enroll purely via frontmatter, and the shipped `devils-advocate` already declares `phase: post-plan`. Migration moves your **active** pipeline into frontmatter **without changing what runs**: agents the plugin already enrolls are left as-is (no redundant copy), your local/modified agents are stamped in place, and any **plugin agent you had enabled that ships dormant** (e.g. an uncommented `standards-enforcer`) is **copied locally and enabled** so it keeps running. Then the stale file is removed.
+
+If there are any ✗ or ⚠ items, ask the user a **single** confirmation:
+> I found {N} items that need attention (including a one-time `pipeline.md` → frontmatter migration). Want me to apply them? The migration runs in one automatic pass — no per-agent prompts.
+
+If the user confirms, proceed to Step 7 and apply **everything** (including the full migration) in a single pass. If everything is current, output "All up to date!" and stop.
 
 ### Step 7: Apply Fixes
 
@@ -111,16 +177,54 @@ For each missing file, generate it by auto-detecting from the project context �
 4. Generate the missing file following the template structure from `project-setup`
 5. Show the user what will be created and confirm before writing
 
-#### Missing plugin-sourced files (pipeline.md)
+#### Legacy `pipeline.md` migration (one automatic pass)
 
-Read the plugin's default and create it in the project. No confirmation needed — this is a default.
+If Step 3 found a legacy `.claude/pipeline.md`, run the **entire** migration now, automatically, in a **single pass** — there are **no per-agent prompts** (the one confirmation in Step 6 already covers all of it):
 
-#### Pipeline differences
+1. **No-op-delete case** (unchanged default): delete `.claude/pipeline.md`. The shipped `devils-advocate` frontmatter already reproduces the default, so nothing is stamped.
 
-For each new phase or missing default agent, ask the user individually:
-> The plugin default includes '{agent-name}' in the {phase} phase. Add it? (y/n)
+2. **Customized case:** execute the per-agent plan from Step 3c for **every** phase and **every** listed active agent, in one go. Per the 3c classification:
+   - **Already provided by the plugin at that phase** → do nothing (the plugin already enrolls it; no file created).
+   - **Genuinely local / modified agent** → stamp its frontmatter in place with `phase` (its heading), `order` (1-based listed position × 10), and `mode` (legacy body heuristic from 3c). Only `phase`/`order`/`mode`. No copy.
+   - **Plugin agent the project had enabled but the plugin ships dormant** → **copy** the plugin's `agents/{name}.md` into `.claude/agents/{name}.md`, then **stamp** the same `phase`/`order`/`mode`, so the agent keeps running. This is required to preserve behavior (report the no-auto-update trade-off).
+   - Then delete `.claude/pipeline.md`.
+   - **Never change what the project runs:** every active agent stays enrolled — via the plugin default, an in-place stamp, or a copy-to-enable. If a genuinely-local agent cannot be stamped, or an entry is unresolvable, **report** it and leave `pipeline.md` in place rather than losing the enrollment.
 
-Only add agents the user approves. Never remove agents the user has added.
+(The `pipeline.md` references in `CLAUDE.md` are scrubbed separately, below — that step runs whether or not a migration happened.)
+
+#### Scrub stale `pipeline.md` references from `CLAUDE.md` (automatic; always runs)
+
+`pipeline.md` is legacy and no longer read, so `CLAUDE.md` must not reference it. Remove **every** stale reference flagged in Step 5 **automatically** — edit `CLAUDE.md` directly, do not merely suggest. This runs regardless of whether a migration happened this session (a project that migrated earlier may still carry a stale reference):
+
+1. **The `<pipeline>` include block, if present** (only HCF's own repo `CLAUDE.md` has one; a generated user `CLAUDE.md` normally does not):
+
+   ```
+   <pipeline>
+   @.claude/pipeline.md
+   </pipeline>
+   ```
+
+   Remove the whole block. If absent, skip silently.
+
+2. **Any other line referencing `pipeline.md`** — e.g. a config-file inventory bullet such as `` - `pipeline.md` - Autonomous development workflow agents `` under a "Files" / "Detailed Configuration" section. Remove each such line, leaving the surrounding lines and the section heading intact (do not delete the whole section).
+
+After scrubbing, `CLAUDE.md` must contain zero references to `pipeline.md`. List each removed line in the Step 8 summary.
+
+#### Missing Feature Development section (automatic; additive)
+
+If Step 5 flagged the Feature Development section as missing (no `hcf:plan-create` reference anywhere in `CLAUDE.md`), add it automatically. This is purely additive — insert a new section, never rewrite or remove existing content. Place it **as the first section**, immediately after the title (`# ...`) and any 1–2 line project description that follows it, and **before the first `##` heading**. Prominence is intentional: an early section reliably overrides competing directives elsewhere in `CLAUDE.md` (e.g. "start from this checklist") that would otherwise suppress the planning trigger. Insert this block verbatim — it is intentionally project-agnostic:
+
+```markdown
+## Feature Development
+
+For any feature or change beyond a simple fix, use the `hcf:plan-create` skill to trigger the autonomous development workflow. Never use Claude Code's built-in plan mode. After writing a plan, ask the user if they want to execute it, and provide the command to run it later with the `hcf:plan-orchestrate` skill.
+
+Use this workflow for: new features, multi-file changes, anything requiring multiple steps or tests.
+
+Skip for: quick bug fixes, single-line changes, questions, documentation. When skipped, still ensure appropriate tests exist for any added functionality.
+```
+
+Do this only when no `plan-create` reference exists — never duplicate or overwrite a section the project already has, even if its wording differs from the block above.
 
 #### Missing CLAUDE.md references
 
@@ -137,15 +241,23 @@ After all fixes are applied, output:
 ```
 Updates applied:
   ✓ Created .claude/architecture.md
-  ✓ Added 'standards-enforcer' to post-implementation pipeline phase
+  ✓ Added Feature Development section to CLAUDE.md (wires up hcf:plan-create / plan-orchestrate)
+  ✓ Migrated legacy pipeline.md → frontmatter (preserved what runs):
+      • devils-advocate    → already provided by the plugin (no change)
+      • standards-enforcer  → enabled via frontmatter (copied into .claude/agents/ so it keeps running)
+  ✓ Deleted .claude/pipeline.md
+  ✓ Removed stale pipeline.md reference(s) from CLAUDE.md
 
 All done!
 ```
 
+If the migration was a no-op delete, the summary instead reads `✓ Removed redundant .claude/pipeline.md (frontmatter already reproduced it)`. If `pipeline.md` was absent, omit the migration lines entirely — but still show the `✓ Removed stale pipeline.md reference(s) from CLAUDE.md` line if any references were scrubbed (an already-migrated project can still have them). If `CLAUDE.md` had no `pipeline.md` references, omit that line too. If `CLAUDE.md` already had a `plan-create` reference, omit the Feature Development line.
+
 ## Error Handling
 
-- If the plugin directory cannot be resolved, report the error and skip plugin-sourced file comparison
-- Never overwrite existing files
-- Never modify `CLAUDE.md` automatically — only suggest changes
-- Never silently remove agents from the pipeline — only suggest additions
+- The migration resolves each entry against the plugin dir (two levels up from this skill file) to classify it. If the plugin directory cannot be resolved, report the error and do NOT delete `pipeline.md` until every entry is classified — surface the unresolved entries and leave the file in place so nothing is silently dropped or disabled.
+- The migration copies a plugin agent into `.claude/agents/` **only** to preserve an enablement the plugin default doesn't provide (case 3 — a dormant plugin agent the project had turned on); it never copies one the plugin already enrolls (that would be a redundant shadow). When stamping an existing local agent, edit it in place to add `phase`/`order`/`mode` — never replace it wholesale.
+- **Removing stale `pipeline.md` references from `CLAUDE.md` is automatic** — `pipeline.md` is legacy and no longer read, so it must not be referenced (see Step 7's scrub subsection; this runs even when no migration happened). **Adding** missing config-file references (Step 7 "Missing CLAUDE.md references") stays suggest-only — never auto-add those.
+- **Adding a missing Feature Development section to `CLAUDE.md` is automatic** but **purely additive** — append the project-agnostic block, never rewrite or delete existing content, and never add it when a `plan-create` reference already exists (the project may have customized the wording). This is what carries the workflow wiring across an upgrade from a pre-frontmatter version.
+- **Never change what the project runs.** Every agent active in the legacy `pipeline.md` ends up enrolled the same way under frontmatter — via the plugin default, an in-place stamp, or a copy-to-enable. Only a truly unresolvable entry is reported and skipped, with `pipeline.md` left in place so the enrollment isn't lost.
 - If auto-detection fails for a generated file, ask the user the relevant questions interactively (same as project-setup would)


### PR DESCRIPTION
## Summary

HCF 2.0.0 replaces the central `pipeline.md` registry with **convention over configuration**: agents enroll themselves into lifecycle hooks via YAML frontmatter (`phase` / `order` / `mode`). This is a **breaking change** — `pipeline.md` is no longer read.

### Added
- **8 lifecycle hook points**: `pre-plan`/`post-plan`, `pre-implementation`/`post-implementation`, `pre-batch`/`post-batch`, `pre-commit`/`post-commit`.
- **`HOOKS.md`** — authoritative reference for hook points, frontmatter schema, discovery routine, and sort/tie-break rules.
- **Migration hooks** (`hooks/`) — `SessionStart` notice plus `PreToolUse`/`UserPromptExpansion` gates that block `plan-create`/`plan-orchestrate` until a legacy `.claude/pipeline.md` is migrated via `/project-update`.
- **Feature Development section** in the generated `CLAUDE.md` from `project-setup`.

### Changed
- Pipeline configured via agent frontmatter instead of `pipeline.md`.
- `plan-orchestrate` reads each agent's `mode` to decide spawn strategy.
- `project-update` migrates a legacy `pipeline.md` into frontmatter (and removes it), and backfills a missing Feature Development section.
- `project-setup`/`project-update` are now command-only (`disable-model-invocation: true`).

### Removed
- `pipeline.md` is no longer read as configuration — no runtime fallback.

### Release
- Version bumped to `2.0.0` in `plugin.json` and `marketplace.json`.
- `CHANGELOG.md` `[2.0.0]` section dated 2026-06-26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)