### PR TITLE
feat(hooks): ship deterministic hook discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# Local Claude Code state: plan scaffolding (.claude/plans/), machine-specific
+# settings, and any fingerprint files HCF writes alongside a plan. Plans are
+# working scaffolding, not deliverables — this repo is the plugin itself and
+# does not run HCF on itself. Use `git add -f` if you ever genuinely want to
+# track something under here.
+.claude/
+
+# Test harness scratch space. run-tests.sh clears this on entry and exit, but a
+# suite that dies mid-run leaves it behind.
+tests/.tmp/
+
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+._*
+
+# Editors
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Conflict and in-place-edit leftovers (git merge, `sed -i.bak`)
+*.orig
+*.rej
+*.bak

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to HCF are documented here. Format follows [Keep a Changelog
 
 ## [Unreleased]
 
+### Added
+- **`hooks/discover-hooks.sh`** — hook discovery is now a shipped script instead of prose instructions the model executed by improvising a bash glob loop. `plan-create` and `plan-orchestrate` run it at all 8 hook call sites and read its output. Closes [#4](https://github.com/markshust/hcf/issues/4), where an improvised enumeration hit a bash syntax error partway through, its partial output was consumed as complete, and **every hook silently resolved empty** — with no error, because the empty-hook silence rule made the failure invisible.
+- **Run it by hand to debug enrollment.** `$(claude plugin path hcf)/hooks/discover-hooks.sh` prints what is enrolled at every hook; add `--hook=<name>` for one, or `--json` for tooling. This is the fastest answer to "why didn't my agent fire?", which previously had no answer at all — the improvised script no longer existed by the time you asked.
+- **Drift detection.** `--fingerprint` captures the resolved enrollment across all 8 hooks; `plan-create` stores it in the plan directory and `plan-orchestrate` re-checks it via `--expect=` on every hook call. If agent files change midway through a run, HCF halts and names what changed rather than silently executing a different pipeline than the plan was reviewed against. Agent *body* content is deliberately not covered — editing an agent's prose is not drift.
+- **Test suite** (`./tests/run-tests.sh`) — 97 tests, no dependencies beyond bash/awk/sed/sort/grep, runnable on bash 3.2 (stock macOS).
+
+### Changed
+- **An invalid `phase` or `mode` in an agent file now aborts (exit 3) instead of being warned past.** Previously an unknown `phase` was ignored with a warning, which meant the agent ran *nowhere* — silent non-execution, the same class of failure as the bug above. Validation is global, so the error surfaces at the first hook of a run rather than hours later. **This can affect existing projects:** if an agent file has a typo'd `phase`, planning now halts until it is fixed. The error names the file, the bad value, and the two remedies — correct the value, or remove the `phase` key entirely to unenroll the agent. Only `plan-create` and `plan-orchestrate` are affected; `/project-update` and every other skill stay runnable.
+- **A frontmatter value carrying a trailing `# …` comment now parses correctly.** The enrollment example documented in `HOOKS.md` and `README.md` uses exactly that form (`phase: post-plan   # enrolls this agent…`), so copy-pasting the documented example previously produced an agent that never ran.
+- Agent files written with **CRLF line endings** are now parsed rather than silently skipped.
+- The local-overrides-plugin merge is keyed on the frontmatter `name`, not the filename.
+- The empty-hook fast path is now defined as **exit 0 with empty stdout**. Any non-zero exit is an error to report loudly — it is no longer possible for a discovery failure to be mistaken for an empty hook.
+- `HOOKS.md`'s Discovery Routine now documents what the script does rather than instructing the reader to enumerate files by hand, and the silent fallback to "local agents only" is gone — losing the plugin's own bundled agents without saying so was itself a failure mode.
+
 ## [2.0.0] — 2026-06-26
 
 ### Added

--- a/HOOKS.md
+++ b/HOOKS.md
@@ -72,55 +72,135 @@ An agent with **no** `phase` key is simply not enrolled in any hook (e.g.
 
 ## Discovery Routine
 
-This is the deterministic, stepwise routine a skill follows to resolve which
-agents run at a given hook. Follow it literally; do not improvise.
+Hook resolution is performed by **`hooks/discover-hooks.sh`**, which ships with
+the plugin. Callers run it and read its output. **Never enumerate agent files by
+hand, and never write a glob loop to do it** — that is exactly the failure this
+script exists to eliminate ([#4](https://github.com/markshust/hcf/issues/4)):
+the routine used to be prose, every session improvised its own bash, one of
+those scripts had a syntax error, and the partial output was consumed as a
+complete enumeration. Every hook silently resolved empty.
 
 Let `HOOK` be the hook point being run (one of the 8 above).
 
-1. **Glob local agents.** List `.claude/agents/*.md` in the current project.
-2. **Glob plugin agents.** List `*.md` in the plugin's `agents/` directory
-   (see [Resolving the plugin `agents/` directory](#resolving-the-plugin-agents-directory)).
-3. **Merge with local override.** Build one set of agents keyed by their
-   frontmatter `name`. A local `.claude/agents` file **OVERRIDES** a plugin
-   agent with the same `name` — the local file wins entirely; the plugin
-   version of that name is discarded (no field-level merge). Plugin agents whose
-   `name` is not shadowed locally are kept.
-4. **Validate phases.** For each merged agent that declares a `phase`: if its
-   `phase` value is **not** one of the 8 known hooks, **ignore** that agent
-   (it never runs) and **print a warning** naming the agent and its unknown
-   phase. Do not let an unknown phase match any hook.
-5. **Filter to this hook.** Keep only agents whose validated frontmatter
-   `phase` equals `HOOK`.
-6. **Empty check.** If the filtered set is empty, this is an **empty hook** —
-   return immediately. See [Empty-hook fast path](#empty-hook-fast-path).
-7. **Sort.** Sort the filtered agents by `order` ascending (a missing `order`
-   is treated as `100`), then by `name` for ties. See
-   [Sort and tie-break](#sort-and-tie-break).
-8. **Print the resolved order.** Before running anything, **PRINT** the
-   resolved, sorted list of agents (name, order, mode) for this hook so the run
-   is auditable.
-9. **Spawn.** Spawn each agent in the sorted order according to its `mode`:
-   - `single` → one subagent for the whole plan.
-   - `batch` → split the relevant file list into batches of ~10 and spawn
-     parallel subagents (one Task call per batch, all in a single message).
+```bash
+"{skill-base-dir}/../../hooks/discover-hooks.sh" --hook=<HOOK>
+```
+
+`{skill-base-dir}` is the **`Base directory for this skill`** value stated when
+the skill loads. It is given verbatim, so no path inference is involved.
+`${CLAUDE_PLUGIN_ROOT}` is **not** available here — it resolves only for
+`hooks.json` entries, not for a skill's own Bash calls.
+
+Then, based on the result:
+
+| Exit | stdout | Meaning | What the caller does |
+|------|--------|---------|----------------------|
+| `0` | non-empty | Agents are enrolled | **Print the output verbatim** (this is the auditable resolved order), then spawn each agent in the listed order per its `mode` |
+| `0` | **empty** | Empty hook | [Empty-hook fast path](#empty-hook-fast-path) — return silently |
+| `1` | — | Runtime error; the plugin `agents/` dir is unresolvable | **Stop.** Surface stderr verbatim |
+| `2` | — | Bad arguments, including a malformed `--expect` value | **Stop.** Surface stderr verbatim |
+| `3` | — | An agent file declares an invalid `phase` or `mode` | **Stop.** Surface stderr verbatim |
+| `4` | — | Enrollment changed mid-run ([drift](#drift-detection)) | **Stop.** Surface stderr verbatim |
+
+**Only exit 0 with empty stdout is an empty hook.** Any non-zero exit is an
+error to report loudly, never a hook to skip silently. Conflating the two is
+what made the original bug invisible for so long.
+
+**If the script is missing or not executable, that is a hard failure.** Say so
+and stop. There is no prose fallback — falling back to hand-enumeration would
+reintroduce improvised bash at exactly the moment the script is unavailable.
+
+Spawn modes: `single` → one subagent for the whole plan. `batch` → split the
+relevant file list into batches of ~10 and spawn parallel subagents (one Task
+call per batch, all in a single message). The mode comes from the agent's
+`mode` field, never from reading its body.
+
+### What the script does (specification)
+
+This is the contract `hooks/discover-hooks.sh` implements. It is here so the
+behavior is reviewable — not as steps for anyone to perform by hand.
+
+1. **Enumerate plugin agents.** Top-level `*.md` in the plugin's `agents/`
+   directory, which the script resolves from its own location
+   (`$(dirname "$0")/../agents`). Not recursive.
+2. **Enumerate local agents.** Top-level `*.md` in
+   `${CLAUDE_PROJECT_DIR:-$PWD}/.claude/agents`. A missing directory is normal,
+   not an error — most projects have none.
+3. **Parse frontmatter.** `name`, `phase`, `order`, `mode` from the **first**
+   `---` block only, anchored at start-of-line. A commented `# phase:` key is
+   **not** enrollment (this is what keeps `standards-enforcer` dormant). Quoted
+   values are unquoted; a trailing ` # …` comment is stripped from unquoted
+   values, so the [example above](#frontmatter-schema) parses as written; CRLF
+   files are handled. A file with no `phase` is simply not enrolled.
+4. **Merge with local override,** keyed on the frontmatter `name` — *not* the
+   filename. A local file **overrides** a plugin agent of the same `name`
+   entirely; there is no field-level merge. Duplicate names within one directory
+   warn and resolve last-wins.
+5. **Validate — fatally.** A `phase` outside the 8 hooks, or a `mode` other than
+   `single`/`batch`, **aborts with exit 3**, naming every offending file and the
+   fix. Validation is **global**: a bad value in a `post-commit` agent aborts a
+   `pre-plan` query, so the problem surfaces at the earliest moment rather than
+   hours later. A non-numeric `order` is milder — it warns and falls back to
+   `100`.
+6. **Filter** to `HOOK` when `--hook` is given.
+7. **Sort** by `order` ascending (missing = `100`), then `name`
+   case-insensitively. See [Sort and tie-break](#sort-and-tie-break).
+
+Other flags: `--json` for machine-readable output, `--fingerprint` /
+`--expect=` for [drift detection](#drift-detection), `--help` for usage. Run it
+with no `--hook` for a by-hand debugging view of all 8 hooks — that is the
+fastest answer to "why didn't my agent fire?".
+
+### Drift detection
+
+Enrollment must not change partway through a run, or the back half of an
+orchestration executes a different pipeline than the plan was built against.
+
+`--fingerprint` prints a stable digest of the fully-resolved enrollment across
+**all 8 hooks**:
+
+```
+discover-hooks-fingerprint-v1 <64-hex>
+```
+
+`plan-create` writes this to `.claude/plans/{plan-name}/.hook-fingerprint`, and
+`plan-orchestrate` passes it back as `--expect=<value>` on every hook call. If
+enrollment changed, the script exits **4** and names what changed; HCF halts.
+
+The hash covers each agent's origin (`plugin` or `local`), `name`, `phase`,
+`order`, and `mode` — never paths, mtimes, or sizes, so it is stable across
+machines and reinstalls. Including origin matters: without it, shadowing a
+plugin agent with a local file carrying identical enrollment keys but entirely
+different instructions would be a silent agent swap.
+
+**Agent body content is deliberately not hashed.** Editing an agent's prose,
+description, or `tools` list is *not* drift. Hashing bodies would fire on every
+typo fix and on any plugin upgrade touching prose, which would make the
+mechanism unusable. Drift detection answers "did the pipeline change?", not
+"did this agent change?".
+
+**Self-inflicted drift.** A plan whose own subject matter is agent files will
+legitimately change enrollment mid-run and halt itself. That is correct, but
+surprising — the escape hatch is to delete `.hook-fingerprint` and re-run to
+re-baseline, which the exit-4 message says. Nothing else HCF does mid-run
+touches `agents/` or `.claude/agents/`.
 
 ### Resolving the plugin `agents/` directory
 
-Resolve the plugin's `agents/` directory **concretely** from the running
-skill's own file path. A skill lives at `skills/{name}/SKILL.md` inside the
-plugin, so the plugin root is **two levels up** from the skill file, and the
-agents directory is `{plugin-root}/agents/`. (This matches the convention used
-by `project-update`, which resolves the plugin dir as "two levels up from this
-skill file.")
+The script self-locates: its `agents/` directory is always
+`$(dirname "$0")/../agents`, so it must stay in the plugin's `hooks/` directory
+alongside `agents/`. If that directory cannot be found the script **exits 1**
+rather than proceeding with local agents only — silently dropping the plugin's
+own bundled agents is precisely the failure mode being fixed.
 
-If the plugin `agents/` directory **cannot be resolved** from the skill path,
-fall back to using `.claude/agents` **only** (skip the plugin agents in steps 2
-and 3, and proceed with whatever local agents exist).
+(`project-update` separately resolves the plugin directory as "two levels up
+from this skill file" for its legacy-migration path. That convention still
+applies there and is unrelated to discovery.)
 
 ### Empty-hook fast path
 
-A hook is **empty** when, after the local-overrides-plugin merge and the
-filter-to-this-hook step, **zero** agents have a `phase` equal to this hook.
+A hook is **empty** when `discover-hooks.sh --hook=<HOOK>` exits **0** with
+**empty stdout**. A non-zero exit is *not* an empty hook — see the table above.
 
 When a hook is empty:
 - **Return immediately.**
@@ -131,12 +211,21 @@ When a hook is empty:
   The entire discovery routine for an empty hook is **silent and internal** —
   nothing about it reaches the user-visible output.
 - Do **no work** — no staging, no diffing, no subagent spawns.
+- Do **not narrate the script call either.** A filtered query on an empty hook
+  prints zero bytes precisely so there is nothing to echo. Do not say "the
+  discovery script returned no agents" — that is the same narration wearing a
+  different hat.
 
 This keeps unused hooks free of overhead and noise. The common failure mode is
 "thinking out loud" — narrating *why* a hook is empty (e.g. "standards-enforcer
 and tdd-worker declare no phase, so this hook is a no-op"). That narration is
 exactly what the fast path forbids: an empty hook is invisible, full stop. Only
 a **non-empty** hook produces visible output (its printed resolved order).
+
+The script itself is louder than its callers on purpose: run with **no**
+`--hook`, it prints an explicit `(empty — …)` marker for every unenrolled hook,
+because that mode exists for a human debugging by hand. The silence rule governs
+what *skills* emit, not what the script can tell you when you ask it directly.
 
 ### Sort and tie-break
 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,26 @@ Enable, add, remove, or reorder agents by editing frontmatter — never a centra
 
 - **Disable an agent.** Remove (or comment out) its `phase` key — there is no condition to toggle.
 
-The agent's **filename** (without `.md`) should match its frontmatter `name`. Local agents in `.claude/agents/` override plugin agents with the same `name` (the local file wins entirely).
+The agent's **filename** (without `.md`) should match its frontmatter `name`. Local agents in `.claude/agents/` override plugin agents with the same `name` (the local file wins entirely) — the override is keyed on the frontmatter `name`, not the filename.
+
+**Check what's actually enrolled.** After editing frontmatter, run the discovery script to confirm it took effect. This is the first thing to try when an agent doesn't fire:
+
+```bash
+$(claude plugin path hcf)/hooks/discover-hooks.sh
+```
+
+```
+# hook: pre-plan
+  (empty — no agents enrolled at this hook)
+
+# hook: post-plan
+  order=10    name=devils-advocate                          mode=single
+...
+```
+
+Add `--hook=post-plan` for one hook, or `--json` for machine-readable output. HCF's planning skills run this exact script rather than enumerating agent files themselves, so what it prints is what will run.
+
+A **non-zero exit means discovery genuinely failed** — it is not the same as a hook being empty. Exit `3` means an agent file declares an invalid `phase` or `mode` (the message names the file and the fix); exit `4` means enrollment changed partway through a run. Both halt HCF deliberately, rather than quietly running a different pipeline than you configured.
 
 > **Upgrading from `pipeline.md`:** Earlier versions of HCF configured the pipeline in a central `.claude/pipeline.md` file. That file is **no longer read** — agent frontmatter is now the only source of pipeline configuration. If a leftover `.claude/pipeline.md` is present, HCF **blocks `plan-create` and `plan-orchestrate`** (you'll see a prompt on session start and when you try to plan) until you run **`/project-update`**, which migrates your configuration into agent frontmatter and removes the file. `/project-update` is never blocked, and the gate clears automatically once the file is gone.
 
@@ -302,6 +321,13 @@ hcf/
 │   ├── devils-advocate.md    # Plan reviewer - finds gaps before execution (opus)
 │   ├── tdd-worker.md         # TDD implementation worker (sonnet)
 │   └── standards-enforcer.md # Code standards enforcement (sonnet)
+├── hooks/
+│   ├── discover-hooks.sh     # Deterministic hook-agent discovery (see HOOKS.md)
+│   ├── detect-legacy-pipeline.sh # SessionStart warning for a legacy pipeline.md
+│   ├── gate-skill.sh         # PreToolUse gate on the planning skills
+│   ├── gate-command.sh       # UserPromptExpansion gate on the planning skills
+│   ├── pipeline-status.sh    # Shared helper sourced by the gates
+│   └── hooks.json            # Lifecycle hook registrations
 ├── skills/
 │   ├── project-setup/
 │   │   └── SKILL.md          # One-time setup skill (manual invocation only)
@@ -311,6 +337,11 @@ hcf/
 │   │   └── SKILL.md          # Interactive planning skill (auto-triggers)
 │   └── plan-orchestrate/
 │       └── SKILL.md          # Parallel TDD execution skill (auto-triggers)
+├── tests/
+│   ├── run-tests.sh          # Test suite entry point (no dependencies)
+│   ├── lib.sh                # Assertions and fixture helpers
+│   ├── test-*.sh             # Suites, auto-discovered by run-tests.sh
+│   └── fixtures/             # Agent files exercising parser edge cases
 ├── HOOKS.md                  # Authoritative hook/frontmatter reference
 ├── CLAUDE.md                 # Portable CLAUDE.md template for projects
 └── README.md

--- a/hooks/discover-hooks.sh
+++ b/hooks/discover-hooks.sh
@@ -1,0 +1,448 @@
+#!/usr/bin/env bash
+# HCF hook discovery — deterministic enumeration of hook-enrolled agents.
+#
+# Why this exists: HCF's discovery routine used to be prose instructions that
+# the in-session model executed by improvising a bash glob loop. Different
+# sessions wrote different scripts, and a syntax error in one of them crashed
+# mid-enumeration; the partial output was consumed as complete, every hook
+# resolved empty, and the empty-hook silence rule made the failure invisible.
+# See https://github.com/markshust/hcf/issues/4.
+#
+# This script is the single implementation of HOOKS.md's Discovery Routine.
+# Callers run it and read its output; nobody enumerates agent files by hand.
+#
+# Usage:
+#   discover-hooks.sh                     # all 8 hooks (by-hand debugging view)
+#   discover-hooks.sh --hook=<name>       # one hook; empty prints nothing
+#   discover-hooks.sh --json              # machine-readable
+#   discover-hooks.sh --fingerprint       # stable enrollment digest
+#   discover-hooks.sh --expect=<value>    # halt if enrollment drifted
+#
+# Exit codes:
+#   0  success (including a legitimately empty hook)
+#   1  runtime error (plugin agents/ dir unresolvable)
+#   2  bad arguments (incl. a malformed --expect value)
+#   3  enrollment validation failure (invalid phase or mode in an agent file)
+#   4  enrollment drift (--expect mismatch)
+
+set -o pipefail
+
+PROG="discover-hooks"
+VALID_HOOKS="pre-plan post-plan pre-implementation pre-batch post-batch post-implementation pre-commit post-commit"
+VALID_MODES="single batch"
+FP_PREFIX="discover-hooks-fingerprint"
+FP_VERSION="1"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_AGENTS="$SCRIPT_DIR/../agents"
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
+LOCAL_AGENTS="$PROJECT_DIR/.claude/agents"
+
+HOOK_FILTER=""
+WANT_JSON=""
+WANT_FINGERPRINT=""
+EXPECT=""
+HAVE_EXPECT=""
+
+warn() { printf '%s: warning: %s\n' "$PROG" "$1" >&2; }
+err()  { printf '%s: error: %s\n'   "$PROG" "$1" >&2; }
+
+usage() {
+  cat <<'EOF'
+discover-hooks.sh — resolve which agents run at an HCF hook point.
+
+  --hook=<name>     Restrict output to one hook. Prints nothing when the hook
+                    resolves empty (callers treat exit 0 + empty stdout as
+                    "empty hook"). Omit to print all 8 hooks with explicit
+                    empty markers, which is the by-hand debugging view.
+  --json            Emit JSON instead of the human table.
+  --fingerprint     Print a stable digest of the full resolved enrollment
+                    across all 8 hooks, then exit.
+  --expect=<value>  Compare current enrollment against a previously captured
+                    fingerprint. Exits 4 if it changed. Accepts either the
+                    full versioned line or the bare 64-hex digest.
+  -h, --help        Show this help.
+
+Exit codes: 0 success, 1 runtime error, 2 bad arguments,
+            3 enrollment validation failure, 4 enrollment drift.
+EOF
+}
+
+is_valid_hook() {
+  case " $VALID_HOOKS " in *" $1 "*) return 0 ;; *) return 1 ;; esac
+}
+
+is_valid_mode() {
+  case " $VALID_MODES " in *" $1 "*) return 0 ;; *) return 1 ;; esac
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --hook=*)
+      HOOK_FILTER="${1#*=}"
+      if [ -z "$HOOK_FILTER" ]; then
+        err "--hook requires a value; use --hook=<name>"
+        exit 2
+      fi
+      if ! is_valid_hook "$HOOK_FILTER"; then
+        err "unknown hook '$HOOK_FILTER'"
+        err "  valid hooks: $VALID_HOOKS"
+        exit 2
+      fi
+      ;;
+    --hook)
+      err "--hook must be given as --hook=<name>, not as two arguments"
+      exit 2
+      ;;
+    --expect=*)
+      EXPECT="${1#*=}"
+      HAVE_EXPECT=1
+      ;;
+    --expect)
+      err "--expect must be given as --expect=<value>, not as two arguments"
+      exit 2
+      ;;
+    --json)        WANT_JSON=1 ;;
+    --fingerprint) WANT_FINGERPRINT=1 ;;
+    -h|--help)     usage; exit 0 ;;
+    *)
+      err "unknown argument '$1'"
+      err "  run with --help for usage"
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+if [ -n "$WANT_FINGERPRINT" ] && [ -n "$HAVE_EXPECT" ]; then
+  err "--fingerprint and --expect are mutually exclusive"
+  exit 2
+fi
+
+# --- frontmatter parsing ----------------------------------------------------
+#
+# Anchored at start-of-line inside the FIRST `---` block only, so a commented
+# `# phase:` key never enrolls an agent. This matters concretely: the bundled
+# standards-enforcer ships dormant with its phase commented out, and an
+# unanchored match would silently enable it for every HCF user.
+
+has_frontmatter() {
+  # NOTE: awk's `exit` runs the END block, so the result is carried in a flag
+  # rather than as an exit status from inside the body.
+  LC_ALL=C awk '
+    { sub(/\r$/, "") }
+    NR == 1 { if ($0 != "---") { bad = 1; exit } ; next }
+    /^---$/ { found = 1; exit }
+    END { if (found && !bad) exit 0; exit 1 }
+  ' "$1"
+}
+
+# fm_get <file> <key> — echoes the trimmed, unquoted, comment-stripped value.
+fm_get() {
+  LC_ALL=C awk -v key="$2" '
+    { sub(/\r$/, "") }
+    NR == 1 { next }
+    /^---$/ { exit }
+    index($0, key ":") == 1 {
+      val = substr($0, length(key) + 2)
+      sub(/^[ \t]+/, "", val)
+      first = substr(val, 1, 1)
+      if (first == "\"" || first == "'"'"'") {
+        val = substr(val, 2)
+        i = index(val, first)
+        if (i > 0) val = substr(val, 1, i - 1)
+      } else {
+        # Strip a trailing inline comment. HOOKS.md and README.md both document
+        # enrollment as `phase: post-plan   # enrolls this agent...`, so this is
+        # the shape a copy-pasting user actually produces.
+        sub(/[ \t]*#.*$/, "", val)
+      }
+      sub(/[ \t]+$/, "", val)
+      print val
+      exit
+    }
+  ' "$1"
+}
+
+# --- enumeration ------------------------------------------------------------
+
+names=()
+phases=()
+orders=()
+modes=()
+origins=()
+
+VALIDATION_ERRORS=0
+
+index_of_name() {
+  local target="$1" i=0 n=${#names[@]}
+  while [ "$i" -lt "$n" ]; do
+    if [ "${names[$i]}" = "$target" ]; then
+      printf '%s' "$i"
+      return 0
+    fi
+    i=$((i + 1))
+  done
+  return 1
+}
+
+scan_dir() {
+  local dir="$1" origin="$2" f base name phase order mode existing seen_here
+  seen_here=""
+
+  shopt -s nullglob
+  for f in "$dir"/*.md; do
+    [ -f "$f" ] || continue
+    has_frontmatter "$f" || continue
+
+    name="$(fm_get "$f" name)"
+    phase="$(fm_get "$f" phase)"
+    order="$(fm_get "$f" order)"
+    mode="$(fm_get "$f" mode)"
+
+    base="$(basename "$f")"
+    [ -n "$name" ] || name="${base%.md}"
+
+    # No phase key means the agent is not enrolled anywhere. Normal, not a
+    # warning — tdd-worker is spawned directly and never via a hook.
+    [ -n "$phase" ] || continue
+
+    if ! is_valid_hook "$phase"; then
+      err "$f: agent '$name' declares unknown phase '$phase'"
+      err "  valid phases: $VALID_HOOKS"
+      err "  to unenroll this agent instead, remove its 'phase' key entirely"
+      VALIDATION_ERRORS=$((VALIDATION_ERRORS + 1))
+      continue
+    fi
+
+    if [ -n "$mode" ] && ! is_valid_mode "$mode"; then
+      err "$f: agent '$name' declares unknown mode '$mode'"
+      err "  valid modes: $VALID_MODES"
+      VALIDATION_ERRORS=$((VALIDATION_ERRORS + 1))
+      continue
+    fi
+    [ -n "$mode" ] || mode="single"
+
+    if [ -n "$order" ]; then
+      case "$order" in
+        ''|*[!0-9]*)
+          warn "agent '$name' declares non-numeric order '$order'; using 100"
+          order="100"
+          ;;
+      esac
+    else
+      order="100"
+    fi
+
+    case " $seen_here " in
+      *" $name "*)
+        warn "duplicate name '$name' in $dir; '$base' wins over the earlier file"
+        ;;
+    esac
+    seen_here="$seen_here $name"
+
+    if existing="$(index_of_name "$name")"; then
+      # Local overrides plugin entirely — no field-level merge. Within one
+      # directory, last wins (warned about above).
+      phases[existing]="$phase"
+      orders[existing]="$order"
+      modes[existing]="$mode"
+      origins[existing]="$origin"
+    else
+      names[${#names[@]}]="$name"
+      phases[${#phases[@]}]="$phase"
+      orders[${#orders[@]}]="$order"
+      modes[${#modes[@]}]="$mode"
+      origins[${#origins[@]}]="$origin"
+    fi
+  done
+  shopt -u nullglob
+}
+
+if [ ! -d "$PLUGIN_AGENTS" ]; then
+  err "plugin agents directory not found at '$PLUGIN_AGENTS'"
+  err "  the script must stay in the plugin's hooks/ directory alongside agents/"
+  exit 1
+fi
+
+scan_dir "$PLUGIN_AGENTS" plugin
+
+plugin_md_count=0
+shopt -s nullglob
+for _f in "$PLUGIN_AGENTS"/*.md; do plugin_md_count=$((plugin_md_count + 1)); done
+shopt -u nullglob
+if [ "$plugin_md_count" -eq 0 ]; then
+  warn "plugin agents dir '$PLUGIN_AGENTS' contains no .md files"
+fi
+
+# A missing project-local .claude/agents/ is normal — most projects have none.
+if [ -d "$LOCAL_AGENTS" ]; then
+  scan_dir "$LOCAL_AGENTS" local
+fi
+
+if [ "$VALIDATION_ERRORS" -gt 0 ]; then
+  err "enrollment validation failed; fix the file(s) above and re-run"
+  exit 3
+fi
+
+# --- fingerprint ------------------------------------------------------------
+
+canonical_lines() {
+  local i=0 n=${#names[@]}
+  while [ "$i" -lt "$n" ]; do
+    printf '%s|%s|%s|%s|%s\n' \
+      "${origins[$i]}" "${names[$i]}" "${phases[$i]}" "${orders[$i]}" "${modes[$i]}"
+    i=$((i + 1))
+  done
+}
+
+compute_fingerprint() {
+  local digest
+  if command -v shasum >/dev/null 2>&1; then
+    digest="$(canonical_lines | LC_ALL=C sort | shasum -a 256)"
+  elif command -v sha256sum >/dev/null 2>&1; then
+    digest="$(canonical_lines | LC_ALL=C sort | sha256sum)"
+  else
+    err "neither shasum nor sha256sum is available; cannot compute a fingerprint"
+    exit 1
+  fi
+  # Both print "<hash>  -"; take field 1 identically from either.
+  printf '%s' "${digest%% *}"
+}
+
+if [ -n "$WANT_FINGERPRINT" ]; then
+  printf '%s-v%s %s\n' "$FP_PREFIX" "$FP_VERSION" "$(compute_fingerprint)"
+  exit 0
+fi
+
+if [ -n "$HAVE_EXPECT" ]; then
+  expect_hash=""
+  expect_version=""
+  case "$EXPECT" in
+    "$FP_PREFIX"-v*\ *)
+      expect_version="${EXPECT#"$FP_PREFIX"-v}"
+      expect_version="${expect_version%% *}"
+      expect_hash="${EXPECT##* }"
+      ;;
+    *)
+      expect_hash="$EXPECT"
+      expect_version="$FP_VERSION"
+      ;;
+  esac
+
+  valid_hash=1
+  case "$expect_hash" in
+    *[!0-9a-f]*) valid_hash="" ;;
+    *) [ "${#expect_hash}" -eq 64 ] || valid_hash="" ;;
+  esac
+  case "$expect_version" in
+    ''|*[!0-9]*) valid_hash="" ;;
+  esac
+
+  if [ -z "$valid_hash" ]; then
+    # A botched write must not masquerade as drift — that would halt the run
+    # with a message pointing at entirely the wrong cause.
+    err "malformed --expect value '$EXPECT'"
+    err "  expected '$FP_PREFIX-v$FP_VERSION <64-hex>' or a bare 64-hex digest"
+    exit 2
+  fi
+
+  if [ "$expect_version" != "$FP_VERSION" ]; then
+    # The hash algorithm changed, not the enrollment. Treat like a missing
+    # fingerprint so a format bump does not brick every existing plan.
+    warn "fingerprint version v$expect_version predates this script (v$FP_VERSION); skipping the drift check"
+  else
+    actual="$(compute_fingerprint)"
+    if [ "$actual" != "$expect_hash" ]; then
+      err "hook enrollment changed since this run started"
+      err "  expected fingerprint: $expect_hash"
+      err "  current fingerprint:  $actual"
+      err "  current enrollment:"
+      if [ "${#names[@]}" -eq 0 ]; then
+        err "    (no agents enrolled at any hook)"
+      else
+        canonical_lines | LC_ALL=C sort | while IFS='|' read -r o n p ord m; do
+          err "    $n ($p, order=$ord, mode=$m, $o)"
+        done
+      fi
+      err "HCF halted. Re-run the plan to pick up the new configuration."
+      err "if this change was intentional, delete"
+      err "  .claude/plans/<plan-name>/.hook-fingerprint and re-run to re-baseline."
+      exit 4
+    fi
+  fi
+fi
+
+# --- output -----------------------------------------------------------------
+
+# Emits "order|name|mode" for one hook, sorted by order asc then name
+# case-insensitively. LC_ALL=C keeps the tie-break identical on a macOS
+# en_US.UTF-8 box and a Linux C one.
+rows_for_hook() {
+  local hook="$1" i=0 n=${#names[@]}
+  while [ "$i" -lt "$n" ]; do
+    if [ "${phases[$i]}" = "$hook" ]; then
+      printf '%s|%s|%s\n' "${orders[$i]}" "${names[$i]}" "${modes[$i]}"
+    fi
+    i=$((i + 1))
+  done | LC_ALL=C sort -t'|' -k1,1n -k2,2f
+}
+
+json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  printf '%s' "$s"
+}
+
+if [ -n "$WANT_JSON" ]; then
+  printf '{"hooks":{'
+  hook_sep=""
+  for hook in ${HOOK_FILTER:-$VALID_HOOKS}; do
+    printf '%s"%s":[' "$hook_sep" "$hook"
+    row_sep=""
+    while IFS='|' read -r ord nm md; do
+      [ -n "$nm" ] || continue
+      printf '%s{"name":"%s","order":%s,"mode":"%s"}' \
+        "$row_sep" "$(json_escape "$nm")" "$ord" "$(json_escape "$md")"
+      row_sep=","
+    done <<EOF
+$(rows_for_hook "$hook")
+EOF
+    printf ']'
+    hook_sep=","
+  done
+  printf '}}\n'
+  exit 0
+fi
+
+if [ -n "$HOOK_FILTER" ]; then
+  # Filtered and empty prints ABSOLUTELY NOTHING. A Bash call's stdout is
+  # visible in the transcript, so any marker here would violate HOOKS.md's rule
+  # that an empty hook is completely invisible to the user.
+  rows="$(rows_for_hook "$HOOK_FILTER")"
+  [ -n "$rows" ] || exit 0
+  printf '# hook: %s\n' "$HOOK_FILTER"
+  printf '%s\n' "$rows" | while IFS='|' read -r ord nm md; do
+    printf '  order=%-5s name=%-40s mode=%s\n' "$ord" "$nm" "$md"
+  done
+  exit 0
+fi
+
+# Unfiltered: the by-hand debugging view, where explicit empty markers ARE
+# wanted. Nothing consumes this programmatically.
+first=1
+for hook in $VALID_HOOKS; do
+  [ "$first" -eq 1 ] || printf '\n'
+  first=0
+  printf '# hook: %s\n' "$hook"
+  rows="$(rows_for_hook "$hook")"
+  if [ -z "$rows" ]; then
+    printf '  (empty — no agents enrolled at this hook)\n'
+  else
+    printf '%s\n' "$rows" | while IFS='|' read -r ord nm md; do
+      printf '  order=%-5s name=%-40s mode=%s\n' "$ord" "$nm" "$md"
+    done
+  fi
+done
+exit 0

--- a/skills/plan-create/SKILL.md
+++ b/skills/plan-create/SKILL.md
@@ -22,9 +22,25 @@ Run this once, at the very start, before Phase 1 discovery.
 
 **Run the `pre-plan` hook.**
 
-Resolve and run agents enrolled at the `pre-plan` hook using the `HOOKS.md` Discovery Routine (glob local `.claude/agents/*.md`, glob the plugin `agents/` directory resolved **two levels up from this `SKILL.md`** per HOOKS.md, merge with local override, validate phases, filter to `pre-plan`, sort by `order` then `name`). This hook is **empty by default** — if no agent declares `phase: pre-plan`, take the empty-hook fast path: return immediately, print nothing, spawn nothing, and proceed to Phase 1.
+Run the discovery script — never enumerate agent files by hand:
 
-If the hook is non-empty, **print the resolved agent order** (name, order, mode) before spawning, then spawn each agent in order per its `mode`.
+```bash
+"{skill-base-dir}/../../hooks/discover-hooks.sh" --hook=pre-plan
+```
+
+`{skill-base-dir}` is the **`Base directory for this skill`** value stated when this skill loaded. `${CLAUDE_PLUGIN_ROOT}` is not available in a skill's Bash calls.
+
+- **Exit 0, empty stdout** → empty hook. This is the default. Return immediately: print nothing, spawn nothing, say nothing about the hook at all, and proceed to Phase 1. Do **not** narrate that the script returned no agents — that is the narration `HOOKS.md` forbids.
+- **Exit 0, output** → **print the output verbatim** as the resolved agent order, then spawn each listed agent in order per its `mode`.
+- **Any non-zero exit** → **stop**. Surface the script's stderr verbatim and do not continue planning. Exit 3 means an agent file declares an invalid `phase` or `mode`; exit 4 means enrollment drifted. Neither is an empty hook. If the script is missing or not executable, that is also a hard stop — there is no fallback, and you must not reconstruct the routine by hand.
+
+**Capture the enrollment fingerprint** now, for Phase 6's drift check:
+
+```bash
+"{skill-base-dir}/../../hooks/discover-hooks.sh" --fingerprint
+```
+
+Hold that value. **A fingerprint is only ever produced by running the script** — never reconstruct, abbreviate, or recall one from memory. If it is not to hand at Phase 6, re-run the command and say so. A hallucinated digest makes every later check fail with bogus drift and bricks the plan.
 
 **IMPORTANT — no plan name exists yet.** The `pre-plan` hook fires *before* Phase 1 discovery. The plan name and plan directory are not created until Phase 3, so there is **no plan name to pass**. Each `pre-plan` agent receives only:
 1. The raw feature request (the user's verbatim ask).
@@ -123,6 +139,14 @@ mkdir -p .claude/plans/{plan-name}
 ```
 
 Use a kebab-case name derived from the feature (e.g., `user-authentication`, `payment-processing`).
+
+**Record the enrollment fingerprint** so `plan-orchestrate` can detect that hook enrollment changed between planning and execution. Write it by **redirecting a fresh invocation** — do not re-type the value captured at Phase 0:
+
+```bash
+"{skill-base-dir}/../../hooks/discover-hooks.sh" --fingerprint > .claude/plans/{plan-name}/.hook-fingerprint
+```
+
+The file holds exactly that one line and nothing else — no heading, no comment, no explanation. Writing it as a redirect rather than transcribing a remembered value is deliberate: Phases 1–2 are a long interactive stretch, and a value carried across them is exactly what gets lost and then invented.
 
 **Create `_plan.md`:**
 ```markdown
@@ -247,17 +271,25 @@ Show the user a simple dependency tree:
 
 After validating dependencies, resolve and run the agents enrolled at the `post-plan` hook.
 
-**1. Discover `post-plan` agents via frontmatter.**
+**1. Resolve `post-plan` agents.**
 
-Resolve which agents run using the `HOOKS.md` Discovery Routine. Concretely: glob local `.claude/agents/*.md`, glob the plugin `agents/` directory (resolved **two levels up from this `SKILL.md`** per HOOKS.md), merge with local override, validate phases, filter to agents whose frontmatter `phase` equals `post-plan`, then sort by `order` ascending (missing `order` = `100`), tie-broken by case-insensitive `name`.
+Run the discovery script, passing the fingerprint captured at Phase 0 so a mid-planning change to agent files is caught:
+
+```bash
+"{skill-base-dir}/../../hooks/discover-hooks.sh" --hook=post-plan --expect="<phase-0 fingerprint>"
+```
+
+Never enumerate agent files by hand. If the Phase 0 value is not to hand, re-run `--fingerprint` to get a current one rather than inventing a digest.
 
 **2. Empty-hook fast path.**
 
-If the filtered set is empty, this is an empty hook: **return immediately** — print nothing, spawn nothing, do no work — and proceed to Phase 7. (No agent declaring `phase: post-plan` is a valid, clean configuration.)
+**Exit 0 with empty stdout** is an empty hook: **return immediately** — print nothing, spawn nothing, do no work, say nothing about the hook — and proceed to Phase 7. (No agent declaring `phase: post-plan` is a valid, clean configuration.) Do not narrate that the script returned no agents.
 
 **3. Print the resolved agent order.**
 
-If the hook is non-empty, **PRINT** the resolved, sorted list of `post-plan` agents (name, order, mode) before spawning anything, so the run is auditable.
+On **exit 0 with output**, **PRINT that output verbatim** before spawning anything, so the run is auditable.
+
+**On any non-zero exit, stop.** Surface the script's stderr verbatim and do not proceed to Phase 7. Exit 3 means an agent file declares an invalid `phase` or `mode`; exit 4 means enrollment changed since Phase 0 — the plan directory already holds a current fingerprint, so re-running `plan-create` proceeds cleanly. A missing or non-executable script is a hard stop with no fallback.
 
 **4. Spawn each agent in the resolved order**, sequentially:
 

--- a/skills/plan-orchestrate/SKILL.md
+++ b/skills/plan-orchestrate/SKILL.md
@@ -105,6 +105,22 @@ If plan status is `ready`, change to `in_progress`:
 - Edit `.claude/plans/{plan-name}/_plan.md`
 - Set `## Status` to `in_progress`
 
+**Establish the run fingerprint.** Every hook call below passes this back via
+`--expect=`, so that agent files changing mid-run halt the orchestration rather
+than silently swapping the pipeline. Read
+`.claude/plans/{plan-name}/.hook-fingerprint` and handle three distinct states —
+conflating them is the mistake to avoid:
+
+| State | Action |
+|-------|--------|
+| **Present and parseable** (one line: `discover-hooks-fingerprint-v1 <64-hex>`) | Use it as `$RUN_FINGERPRINT`. Pass the file's contents **verbatim** — do not trim, reformat, or re-derive them. |
+| **Missing** | Not an error. Plans created before this feature have none. Capture one and write it to the plan directory so a resumed run is covered too, then continue: `"{skill-base-dir}/../../hooks/discover-hooks.sh" --fingerprint > .claude/plans/{plan-name}/.hook-fingerprint` |
+| **Present but unparseable** (empty, truncated, prose, wrong length) | **Halt.** Do not silently recapture — that would mask a botched write. Tell the user to delete the file to re-baseline. |
+
+**Never reconstruct, abbreviate, or recall a fingerprint from memory.** It is
+only ever produced by running the script. A hallucinated digest fails every
+subsequent hook with bogus drift and bricks the run.
+
 ### Step 2a: Pre-Implementation Hook
 
 Run the `pre-implementation` hook **once**, after the status is set to
@@ -115,8 +131,9 @@ Resolve and run enrolled agents via the **HOOKS.md discovery routine** (see
 each agent the project context as described in
 [Spawning hook agents](#spawning-hook-agents).
 
-If the hook is **empty** (no enrolled agents), honor the **empty-hook fast
-no-op**: return immediately, log nothing, do no work, and proceed to Step 3.
+**Exit 0 with empty stdout** is an empty hook: return immediately, log nothing,
+do no work, and proceed to Step 3. **Any non-zero exit stops the run** — see
+[Hook Discovery](#hook-discovery) for the full result table.
 
 ### Step 3: Find Ready Tasks
 
@@ -155,34 +172,47 @@ if len(ready_tasks) == 0:
 
 All hooks in this skill (`pre-implementation`, `pre-batch`, `post-batch`,
 `post-implementation`, `pre-commit`, `post-commit`) resolve their enrolled
-agents through the **single, authoritative discovery routine defined in
-[HOOKS.md → Discovery Routine](../../HOOKS.md#discovery-routine)**. Follow that
-routine literally; do not duplicate or improvise it here. In summary, for a
+agents by running **`hooks/discover-hooks.sh`**, the single implementation of
+[HOOKS.md → Discovery Routine](../../HOOKS.md#discovery-routine). **Never
+enumerate agent files by hand and never write a glob loop to do it.** For a
 given `HOOK`:
 
-- Glob `.claude/agents/*.md` (local) and the **plugin** `agents/*.md`, with
-  local files overriding plugin agents of the same `name`.
-- **Resolve the plugin `agents/` directory** exactly as HOOKS.md /
-  `project-update` does: it is **two levels up from this `SKILL.md`** (this file
-  lives at `skills/plan-orchestrate/SKILL.md`, so the plugin root is two levels
-  up and the agents directory is `{plugin-root}/agents/`). If it cannot be
-  resolved from the skill path, fall back to `.claude/agents` only.
-- Enrollment is **purely frontmatter-based**: every agent declares its `phase`
-  in frontmatter, so frontmatter is always authoritative. There is no other
-  source to consult or merge.
-- Validate phases, **filter to this `HOOK`**, and sort by `order` ascending then
-  `name` (case-insensitive) for ties.
-- **Empty-hook fast no-op:** if the filtered set is empty, **return
-  immediately** — no staging, no diffing, no spawns, and **no logging or
-  narration**. "No narration" is literal and is the rule most often broken: do
-  not name the hook, do not say it is empty/skipped, and do not explain *why*
-  it is empty (e.g. "tdd-worker and standards-enforcer declare no phase, so this
-  is a no-op"). An empty hook is **completely invisible** in the user-facing
-  output — resolve it silently and move on. See [HOOKS.md → Empty-hook fast
+```bash
+"{skill-base-dir}/../../hooks/discover-hooks.sh" --hook=<HOOK> --expect="$RUN_FINGERPRINT"
+```
+
+`{skill-base-dir}` is the **`Base directory for this skill`** value stated when
+this skill loaded — it is given verbatim, so no path inference is needed.
+`${CLAUDE_PLUGIN_ROOT}` is **not** available in a skill's Bash calls.
+`$RUN_FINGERPRINT` is the value established at [Step 2](#step-2-update-plan-status).
+
+Then, by result:
+
+- **Exit 0, empty stdout → empty hook.** Return immediately — no staging, no
+  diffing, no spawns, and **no logging or narration**. "No narration" is literal
+  and is the rule most often broken: do not name the hook, do not say it is
+  empty/skipped, do not explain *why* it is empty, and **do not say the
+  discovery script returned no agents**. A filtered query prints zero bytes
+  precisely so there is nothing to echo. An empty hook is **completely
+  invisible** in the user-facing output. See [HOOKS.md → Empty-hook fast
   path](../../HOOKS.md#empty-hook-fast-path).
-- Otherwise, **PRINT the resolved order** (each agent's `name`, `order`, `mode`)
-  before spawning anything, then spawn each agent per its **`mode` field**
-  (`single` → one subagent for the whole plan; `batch` → split the relevant file
+- **Exit 0, output → PRINT it verbatim** as the resolved order, then spawn.
+- **Exit 1 or 2 → stop the run.** Surface stderr verbatim.
+- **Exit 3 → stop the run.** An agent file declares an invalid `phase` or
+  `mode`. Surface stderr verbatim; it names the file and the fix.
+- **Exit 4 → halt HCF.** Hook enrollment changed since this run started, so the
+  remaining hooks would execute a different pipeline than the plan was reviewed
+  against. Surface stderr verbatim. Do **not** continue the batch loop and do
+  **not** commit.
+- **Script missing or not executable → hard failure.** Say so and stop. There is
+  no prose fallback; reconstructing the routine by hand is the failure this
+  design exists to end.
+
+**Only exit 0 with empty stdout is an empty hook.** Every other non-zero exit is
+an error to report loudly.
+
+On a normal (exit 0, non-empty) result, spawn each agent per its **`mode` field**
+(`single` → one subagent for the whole plan; `batch` → split the relevant file
   list into batches of ~10 and spawn parallel subagents, one Task call per
   batch, all in a single message). The spawn mode comes from the agent's `mode`
   frontmatter field — never from sniffing the agent body text.
@@ -243,9 +273,9 @@ git add -A && git diff --name-only --cached && git reset HEAD
 ```
 
 Then spawn the resolved agents per their `mode` (see
-[Spawning hook agents](#spawning-hook-agents)). If the hook is **empty**, honor
-the **empty-hook fast no-op** (return immediately, no logging, no work) and
-proceed to step 2.
+[Spawning hook agents](#spawning-hook-agents)). **Exit 0 with empty stdout** is
+an empty hook: return immediately, no logging, no work, and proceed to step 2.
+**Any non-zero exit stops the run** — see [Hook Discovery](#hook-discovery).
 
 **2. After ALL post-implementation agents complete, run validation:**
 ```bash
@@ -263,7 +293,8 @@ implementation only or output `TASKS_BLOCKED`.
 
 Resolve and run enrolled agents via [Hook Discovery](#hook-discovery) with
 `HOOK = pre-commit`. These run *after* the suite passes and *before* the commit.
-Honor the **empty-hook fast no-op**.
+**Exit 0 with empty stdout** is an empty hook (silent no-op); **any non-zero
+exit stops the run before the commit** — see [Hook Discovery](#hook-discovery).
 
 > If a `pre-commit` agent modifies files, those edits are part of this commit. A
 > pre-commit agent that changes files could break tests; that risk is covered by
@@ -287,8 +318,10 @@ git commit -m "feat({plan-name}): {plan title summary}"
 
 Resolve and run enrolled agents via [Hook Discovery](#hook-discovery) with
 `HOOK = post-commit`. These run *after* the commit and *before* the push/PR
-prompt (the [Output Summary](#output-summary) at the end of this skill). Honor
-the **empty-hook fast no-op**.
+prompt (the [Output Summary](#output-summary) at the end of this skill).
+**Exit 0 with empty stdout** is an empty hook (silent no-op); **any non-zero
+exit is reported loudly** — see [Hook Discovery](#hook-discovery). The commit
+has already happened, so report the failure rather than trying to undo it.
 
 > **`post-commit` agents that produce uncommitted changes are REPORTED, not
 > silently committed.** The commit above already happened; do not amend or
@@ -324,8 +357,11 @@ Re-run the test suite on just the implementation.
 **Pre-batch hook (this loop iteration).** Before spawning workers, run the
 `pre-batch` hook via the [Hook Discovery](#hook-discovery) routine with
 `HOOK = pre-batch`. Because this runs on **every** loop iteration, honoring the
-**empty-hook fast no-op** is important: if no agents are enrolled, return
+**empty-hook fast no-op** is important: on **exit 0 with empty stdout**, return
 immediately — log nothing, do no work — so unconfigured loops add zero overhead.
+**Any non-zero exit stops the run**; per-iteration checking is also what makes
+drift (exit 4) surface promptly rather than at the end. See
+[Hook Discovery](#hook-discovery).
 
 For EACH ready task, spawn a Task tool subagent **in parallel** (single message with multiple Task tool calls):
 
@@ -375,7 +411,8 @@ Wait for ALL parallel Task tool calls to complete. For each result:
 
 **Post-batch hook (this loop iteration).** After all results for this batch are
 collected and statuses are updated, run the `post-batch` hook via the
-[Hook Discovery](#hook-discovery) routine with `HOOK = post-batch`. Because this
+[Hook Discovery](#hook-discovery) routine with `HOOK = post-batch`. **Any
+non-zero exit stops the run.** Because this
 runs on **every** loop iteration, honoring the **empty-hook fast no-op** is
 important: if no agents are enrolled, return immediately — log nothing, do no
 work — so unconfigured loops add zero overhead.

--- a/skills/project-setup/SKILL.md
+++ b/skills/project-setup/SKILL.md
@@ -266,11 +266,12 @@ Example:
 
 **Pipeline enrollment (nothing to scaffold):**
 
-Pipeline agents enroll via their own frontmatter (`phase:`), so a fresh setup already has a working pipeline from the plugin's bundled agents — nothing to scaffold here. `devils-advocate` runs at `post-plan`; `standards-enforcer` ships dormant (uncomment its `phase` to enable). See `HOOKS.md`.
+Pipeline agents enroll via their own frontmatter (`phase:`), so a fresh setup already has a working pipeline from the plugin's bundled agents — nothing to scaffold here. `devils-advocate` runs at `post-plan`; `standards-enforcer` ships dormant (uncomment its `phase` to enable). See `HOOKS.md`. Running `hooks/discover-hooks.sh` prints exactly what is enrolled at each hook.
 
 Tell the user:
 > **Pipeline ready.** `devils-advocate` is enrolled at the `post-plan` hook via its own agent frontmatter, so it runs automatically when you create a plan. `standards-enforcer` ships with HCF but is dormant — uncomment its `phase` key in the agent's frontmatter to enable code-standards enforcement on changed files.
 > To add your own gate, drop an agent file in `.claude/agents/` and give it a `phase` (one of the 8 hook points). A local agent with the same `name` overrides the plugin's. See `HOOKS.md` for the full hook list and frontmatter schema.
+> To see what is currently enrolled at each hook, run `$(claude plugin path hcf)/hooks/discover-hooks.sh` — that is the fastest answer whenever an agent doesn't fire.
 
 **Create `CLAUDE.md` in project root:**
 

--- a/tests/fixtures/alpha.md
+++ b/tests/fixtures/alpha.md
@@ -1,0 +1,9 @@
+---
+name: alpha
+description: "Ordinary enrolled agent."
+phase: post-plan
+order: 10
+mode: single
+---
+
+Body text.

--- a/tests/fixtures/apple.md
+++ b/tests/fixtures/apple.md
@@ -1,0 +1,9 @@
+---
+name: Apple
+description: "Equal order with banana; tie-break must be case-insensitive."
+phase: pre-commit
+order: 50
+mode: single
+---
+
+Body text.

--- a/tests/fixtures/bad-mode.md
+++ b/tests/fixtures/bad-mode.md
@@ -1,0 +1,9 @@
+---
+name: bad-mode
+description: "FATAL fixture. Only ever placed in dirs whose tests expect exit 3."
+phase: post-commit
+order: 10
+mode: batched
+---
+
+Body text.

--- a/tests/fixtures/bad-phase-1.md
+++ b/tests/fixtures/bad-phase-1.md
@@ -1,0 +1,9 @@
+---
+name: bad-phase-1
+description: "FATAL fixture. Only ever placed in dirs whose tests expect exit 3."
+phase: execution
+order: 10
+---
+
+`execution` is documented in HOOKS.md as a hook that deliberately never existed,
+so it is a realistic thing for a user to hand-write.

--- a/tests/fixtures/bad-phase-2.md
+++ b/tests/fixtures/bad-phase-2.md
@@ -1,0 +1,8 @@
+---
+name: bad-phase-2
+description: "FATAL fixture. Second one, so 'reports every offending file' is testable."
+phase: post-plann
+order: 10
+---
+
+A plain typo.

--- a/tests/fixtures/banana.md
+++ b/tests/fixtures/banana.md
@@ -1,0 +1,9 @@
+---
+name: banana
+description: "Equal order with Apple; tie-break must be case-insensitive."
+phase: pre-commit
+order: 50
+mode: single
+---
+
+Body text.

--- a/tests/fixtures/body-phase.md
+++ b/tests/fixtures/body-phase.md
@@ -1,0 +1,9 @@
+---
+name: body-phase
+description: "Frontmatter declares no phase; the body mentions one."
+---
+
+phase: post-plan
+
+The line above sits outside the frontmatter block and must never enroll this
+agent.

--- a/tests/fixtures/crlf.md
+++ b/tests/fixtures/crlf.md
@@ -1,0 +1,9 @@
+---
+name: crlf
+description: "Authored on Windows; CRLF must not silently unenroll it."
+phase: post-plan
+order: 40
+mode: single
+---
+
+Body text.

--- a/tests/fixtures/defaults.md
+++ b/tests/fixtures/defaults.md
@@ -1,0 +1,7 @@
+---
+name: defaults
+description: "Declares phase only; order and mode must default to 100 and single."
+phase: pre-batch
+---
+
+Body text.

--- a/tests/fixtures/documented-example.md
+++ b/tests/fixtures/documented-example.md
@@ -1,0 +1,13 @@
+---
+name: documented-example
+description: "..."
+model: opus
+tools: Read, Write, Edit, Glob, Grep
+# --- hook enrollment ---
+phase: post-plan   # enrolls this agent at the named hook point
+order: 100         # integer; lower runs first; default 100
+mode: single       # "single" | "batch"; default "single"
+---
+
+Copied verbatim from the frontmatter example in HOOKS.md and README.md. A user
+who copy-pastes the documented example must get a working agent.

--- a/tests/fixtures/dormant.md
+++ b/tests/fixtures/dormant.md
@@ -1,0 +1,12 @@
+---
+name: dormant
+description: "Mirrors the shipped standards-enforcer: enrollment keys commented out."
+model: opus
+tools: Read, Edit, Glob, Grep
+# To enable this after implementation, uncomment:
+# phase: post-implementation
+# order: 50
+# mode: batch
+---
+
+Ships dormant. Must never enroll until a human uncomments the keys.

--- a/tests/fixtures/dup-a.md
+++ b/tests/fixtures/dup-a.md
@@ -1,0 +1,9 @@
+---
+name: dupe
+description: "Two files in one directory declaring the same name."
+phase: post-plan
+order: 10
+mode: single
+---
+
+Body text.

--- a/tests/fixtures/dup-b.md
+++ b/tests/fixtures/dup-b.md
@@ -1,0 +1,9 @@
+---
+name: dupe
+description: "Two files in one directory declaring the same name; sorts after dup-a.md."
+phase: post-batch
+order: 70
+mode: batch
+---
+
+Body text.

--- a/tests/fixtures/no-frontmatter.md
+++ b/tests/fixtures/no-frontmatter.md
@@ -1,0 +1,5 @@
+# Just a markdown file
+
+No frontmatter block at all. Must be skipped without erroring.
+
+phase: post-plan

--- a/tests/fixtures/no-phase.md
+++ b/tests/fixtures/no-phase.md
@@ -1,0 +1,7 @@
+---
+name: no-phase
+description: "Mirrors tdd-worker: spawned directly, never via a hook."
+model: sonnet
+---
+
+Declares no phase, so it is enrolled nowhere. This is normal, not a warning.

--- a/tests/fixtures/noname.md
+++ b/tests/fixtures/noname.md
@@ -1,0 +1,7 @@
+---
+description: "Declares no name key; must fall back to the filename."
+phase: pre-implementation
+order: 30
+---
+
+Body text.

--- a/tests/fixtures/nonnumeric-order.md
+++ b/tests/fixtures/nonnumeric-order.md
@@ -1,0 +1,9 @@
+---
+name: nonnumeric-order
+description: "Non-numeric order warns and falls back to 100."
+phase: post-batch
+order: high
+mode: single
+---
+
+Body text.

--- a/tests/fixtures/quoted.md
+++ b/tests/fixtures/quoted.md
@@ -1,0 +1,9 @@
+---
+name: "quoted # not-a-comment"
+description: "Values may be quoted; a hash inside quotes is data, not a comment."
+phase: "pre-commit"
+order: 20
+mode: 'single'
+---
+
+Body text.

--- a/tests/fixtures/shadow-local.md
+++ b/tests/fixtures/shadow-local.md
@@ -1,0 +1,9 @@
+---
+name: shared-agent
+description: "Local override. Deliberately a different FILENAME to prove the merge keys on the frontmatter name."
+phase: pre-commit
+order: 90
+mode: batch
+---
+
+Local body. Overrides the plugin agent entirely — no field-level merge.

--- a/tests/fixtures/shadow-plugin.md
+++ b/tests/fixtures/shadow-plugin.md
@@ -1,0 +1,9 @@
+---
+name: shared-agent
+description: "Plugin-side agent. A local file with the same NAME but a different FILENAME must override it."
+phase: post-plan
+order: 10
+mode: single
+---
+
+Plugin body.

--- a/tests/fixtures/unterminated.md
+++ b/tests/fixtures/unterminated.md
@@ -1,0 +1,6 @@
+---
+name: unterminated
+phase: post-plan
+order: 10
+
+The frontmatter block above is never closed. Must be skipped without erroring.

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Shared assertions and fixture helpers for the HCF test suite.
+#
+# Zero dependencies beyond bash/awk/sed/sort/grep, and must run under bash 3.2
+# (stock macOS /bin/bash) as well as modern Linux bash.
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FIXTURES="$REPO_ROOT/tests/fixtures"
+
+# Every invocation runs through here. The suite executes inside a Claude Code
+# session where CLAUDE_PROJECT_DIR and CLAUDE_PLUGIN_ROOT may be exported; if
+# they leaked in, the script would resolve a real project instead of the
+# fixture sandbox and the tests would silently test the wrong thing.
+run_script() {
+  local plugin_root="$1"; shift
+  local project_dir="$1"; shift
+  env -u CLAUDE_PLUGIN_ROOT \
+    CLAUDE_PROJECT_DIR="$project_dir" \
+    "$plugin_root/hooks/discover-hooks.sh" "$@"
+}
+
+# Build a throwaway plugin root containing a copy of the real script plus an
+# agents/ dir composed from the named fixture files. The script self-locates
+# from ${BASH_SOURCE[0]}, so copying it in is how tests point it at fixture
+# agents — there is deliberately no --target flag to override that path.
+#
+#   make_plugin_root <dest> [fixture-file ...]
+make_plugin_root() {
+  local dest="$1"; shift
+  mkdir -p "$dest/hooks" "$dest/agents"
+  cp "$REPO_ROOT/hooks/discover-hooks.sh" "$dest/hooks/"
+  chmod +x "$dest/hooks/discover-hooks.sh"
+  local f
+  for f in "$@"; do
+    cp "$FIXTURES/$f" "$dest/agents/"
+  done
+  printf '%s' "$dest"
+}
+
+#   make_project <dest> [fixture-file ...]   -> project root with .claude/agents
+make_project() {
+  local dest="$1"; shift
+  mkdir -p "$dest/.claude/agents"
+  local f
+  for f in "$@"; do
+    cp "$FIXTURES/$f" "$dest/.claude/agents/"
+  done
+  printf '%s' "$dest"
+}
+
+new_tmpdir() {
+  mkdir -p "$REPO_ROOT/tests/.tmp"
+  mktemp -d "$REPO_ROOT/tests/.tmp/t.XXXXXX"
+}
+
+_pass() {
+  TESTS_RUN=$((TESTS_RUN + 1))
+  printf '  \033[32m✓\033[0m %s\n' "$1"
+}
+
+_fail() {
+  TESTS_RUN=$((TESTS_RUN + 1))
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+  printf '  \033[31m✗\033[0m %s\n' "$1"
+  shift
+  local line
+  for line in "$@"; do
+    printf '      %s\n' "$line"
+  done
+}
+
+assert_eq() { # <desc> <expected> <actual>
+  if [ "$2" = "$3" ]; then
+    _pass "$1"
+  else
+    _fail "$1" "expected: [$2]" "actual:   [$3]"
+  fi
+}
+
+assert_exit() { # <desc> <expected-code> <actual-code>
+  if [ "$2" = "$3" ]; then
+    _pass "$1"
+  else
+    _fail "$1" "expected exit $2, got $3"
+  fi
+}
+
+assert_contains() { # <desc> <haystack> <needle>
+  case "$2" in
+    *"$3"*) _pass "$1" ;;
+    *) _fail "$1" "expected to contain: [$3]" "actual: [$2]" ;;
+  esac
+}
+
+assert_not_contains() { # <desc> <haystack> <needle>
+  case "$2" in
+    *"$3"*) _fail "$1" "expected NOT to contain: [$3]" "actual: [$2]" ;;
+    *) _pass "$1" ;;
+  esac
+}
+
+assert_empty() { # <desc> <actual>
+  if [ -z "$2" ]; then
+    _pass "$1"
+  else
+    _fail "$1" "expected empty output" "actual: [$2]"
+  fi
+}
+
+# Collapses runs of whitespace so assertions describe fields rather than column
+# padding. The exact alignment of the human table is cosmetic; what it *says*
+# is not.
+normalize_ws() {
+  printf '%s' "$1" | tr -s '[:space:]' ' ' | sed 's/^ //; s/ $//'
+}

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# HCF test suite. Zero dependencies: bash 3.2+, awk, sed, sort, grep.
+#
+#   ./tests/run-tests.sh              # all suites
+#   ./tests/run-tests.sh test-parse   # one suite (with or without .sh)
+
+set -o pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tests/lib.sh
+. "$DIR/lib.sh"
+
+rm -rf "$DIR/.tmp"
+
+if [ $# -gt 0 ]; then
+  suites=""
+  for arg in "$@"; do
+    name="${arg%.sh}"
+    if [ -f "$DIR/$name.sh" ]; then
+      suites="$suites $DIR/$name.sh"
+    else
+      printf 'run-tests: no such suite: %s\n' "$name" >&2
+      exit 2
+    fi
+  done
+else
+  shopt -s nullglob
+  suites=""
+  for f in "$DIR"/test-*.sh; do
+    suites="$suites $f"
+  done
+  shopt -u nullglob
+fi
+
+if [ -z "$suites" ]; then
+  printf 'run-tests: no suites found in %s\n' "$DIR" >&2
+  exit 2
+fi
+
+for suite in $suites; do
+  printf '\n\033[1m%s\033[0m\n' "$(basename "$suite" .sh)"
+  # Sourced, not executed, so counters accumulate across suites.
+  # shellcheck source=/dev/null
+  . "$suite"
+done
+
+rm -rf "$DIR/.tmp"
+
+printf '\n'
+if [ "$TESTS_FAILED" -eq 0 ]; then
+  printf '\033[32m%d passed\033[0m\n' "$TESTS_RUN"
+  exit 0
+fi
+printf '\033[31m%d failed\033[0m, %d passed, %d total\n' \
+  "$TESTS_FAILED" "$((TESTS_RUN - TESTS_FAILED))" "$TESTS_RUN"
+exit 1

--- a/tests/test-args.sh
+++ b/tests/test-args.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Argument parsing, directory resolution, and the exit-code contract.
+
+TMP="$(new_tmpdir)"
+PLUGIN="$(make_plugin_root "$TMP/plugin" alpha.md)"
+PROJECT="$(make_project "$TMP/project")"
+
+out="$(run_script "$PLUGIN" "$PROJECT" --help 2>&1)"; code=$?
+assert_exit "it exits 0 for --help" 0 "$code"
+assert_contains "it prints usage for --help" "$out" "--hook=<name>"
+
+run_script "$PLUGIN" "$PROJECT" --bogus >/dev/null 2>&1
+assert_exit "it exits 2 on an unrecognized flag" 2 "$?"
+
+run_script "$PLUGIN" "$PROJECT" --hook=not-a-hook >/dev/null 2>&1
+assert_exit "it exits 2 when --hook names a value outside the 8 known hooks" 2 "$?"
+
+run_script "$PLUGIN" "$PROJECT" --hook= >/dev/null 2>&1
+assert_exit "it exits 2 when --hook is given an empty value" 2 "$?"
+
+out="$(run_script "$PLUGIN" "$PROJECT" --hook post-plan 2>&1)"; code=$?
+assert_exit "it exits 2 when --hook is given in the space-separated form" 2 "$code"
+assert_contains "it names the accepted form in the space-separated error" "$out" "--hook=<name>"
+
+run_script "$PLUGIN" "$PROJECT" --fingerprint --expect=deadbeef >/dev/null 2>&1
+assert_exit "it exits 2 when --fingerprint and --expect are both given" 2 "$?"
+
+# A project with no .claude/agents at all is the common case, not an error.
+NOLOCAL="$TMP/nolocal"; mkdir -p "$NOLOCAL"
+run_script "$PLUGIN" "$NOLOCAL" --hook=post-plan >/dev/null 2>&1
+assert_exit "it exits 0 when the project has no local agents directory" 0 "$?"
+
+# Plugin agents/ missing entirely: the script cannot do its job.
+BROKEN="$TMP/broken"; mkdir -p "$BROKEN/hooks"
+cp "$REPO_ROOT/hooks/discover-hooks.sh" "$BROKEN/hooks/"
+chmod +x "$BROKEN/hooks/discover-hooks.sh"
+out="$(run_script "$BROKEN" "$PROJECT" --hook=post-plan 2>&1)"; code=$?
+assert_exit "it exits 1 when the plugin agents directory cannot be resolved" 1 "$code"
+assert_contains "it names the missing plugin agents dir" "$out" "plugin agents directory not found"
+
+# Plugin agents/ present but empty: every hook resolving empty because the
+# bundled agents vanished is the original bug reached by another route.
+EMPTYP="$TMP/emptyplugin"; make_plugin_root "$EMPTYP" >/dev/null
+err="$(run_script "$EMPTYP" "$PROJECT" --hook=post-plan 2>&1 >/dev/null)"; code=$?
+assert_exit "it exits 0 when the plugin agents dir has no md files" 0 "$code"
+assert_contains "it warns when the plugin agents dir has no md files" "$err" "contains no .md files"
+
+# Self-location: the plugin dir must come from the script's own path, never cwd.
+out="$(cd / && run_script "$PLUGIN" "$PROJECT" --hook=post-plan 2>/dev/null)"
+assert_contains "it resolves the plugin agents dir relative to the script not the cwd" "$out" "alpha"
+
+# CLAUDE_PROJECT_DIR is how the script finds project-local agents.
+PROJ2="$(make_project "$TMP/proj2" defaults.md)"
+out="$(run_script "$PLUGIN" "$PROJ2" --hook=pre-batch 2>/dev/null)"
+assert_contains "it honors CLAUDE_PROJECT_DIR when locating local agents" "$out" "defaults"
+
+# Real plugin install roots contain spaces.
+SPACED="$TMP/dir with spaces"
+make_plugin_root "$SPACED/plugin" alpha.md >/dev/null
+make_project "$SPACED/project" defaults.md >/dev/null
+out="$(run_script "$SPACED/plugin" "$SPACED/project" 2>/dev/null)"
+assert_contains "it resolves both directories when their paths contain spaces" "$out" "alpha"
+assert_contains "it reads local agents from a path containing spaces" "$out" "defaults"
+
+rm -rf "$TMP"

--- a/tests/test-drift.sh
+++ b/tests/test-drift.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Fingerprint stability and drift detection.
+
+TMP="$(new_tmpdir)"
+PLUGIN="$(make_plugin_root "$TMP/plugin" alpha.md defaults.md)"
+PROJECT="$(make_project "$TMP/project")"
+
+fp() { run_script "$1" "$2" --fingerprint 2>/dev/null; }
+
+base="$(fp "$PLUGIN" "$PROJECT")"
+assert_contains "it prints a versioned fingerprint line" "$base" "discover-hooks-fingerprint-v1 "
+hash="${base##* }"
+assert_eq "it prints a 64-hex digest" "64" "${#hash}"
+assert_eq "it prints the same fingerprint across runs when nothing changed" "$base" "$(fp "$PLUGIN" "$PROJECT")"
+
+# Editing an agent's prose is deliberately NOT drift — hashing bodies would
+# fire on every typo fix and on any plugin upgrade that touches prose.
+printf '\nAn extra paragraph of prose.\n' >> "$PLUGIN/agents/alpha.md"
+assert_eq "it prints the same fingerprint when only an agent body changed" "$base" "$(fp "$PLUGIN" "$PROJECT")"
+
+cp "$FIXTURES/apple.md" "$PLUGIN/agents/"
+added="$(fp "$PLUGIN" "$PROJECT")"
+assert_eq "it prints a different fingerprint when an agent is added" "1" \
+  "$([ "$added" != "$base" ] && echo 1 || echo 0)"
+
+rm -f "$PLUGIN/agents/apple.md"
+assert_eq "it returns to the original fingerprint when the addition is reverted" "$base" "$(fp "$PLUGIN" "$PROJECT")"
+
+rm -f "$PLUGIN/agents/defaults.md"
+removed="$(fp "$PLUGIN" "$PROJECT")"
+assert_eq "it prints a different fingerprint when an agent is removed" "1" \
+  "$([ "$removed" != "$base" ] && echo 1 || echo 0)"
+cp "$FIXTURES/defaults.md" "$PLUGIN/agents/"
+
+sed 's/^order: 10$/order: 20/' "$FIXTURES/alpha.md" > "$PLUGIN/agents/alpha.md"
+reordered="$(fp "$PLUGIN" "$PROJECT")"
+assert_eq "it prints a different fingerprint when an order changed" "1" \
+  "$([ "$reordered" != "$base" ] && echo 1 || echo 0)"
+cp "$FIXTURES/alpha.md" "$PLUGIN/agents/"
+
+# Origin is in the hash: shadowing a plugin agent with a local file carrying
+# identical enrollment keys but a different prompt body would otherwise be a
+# silent agent swap that drift detection never reports.
+SHADOW_P="$(make_plugin_root "$TMP/sp" shadow-plugin.md)"
+SHADOW_L="$(make_project "$TMP/sl")"
+before_shadow="$(fp "$SHADOW_P" "$SHADOW_L")"
+cat > "$SHADOW_L/.claude/agents/shadow-plugin.md" <<'EOF'
+---
+name: shared-agent
+description: "Same enrollment keys, completely different instructions."
+phase: post-plan
+order: 10
+mode: single
+---
+Do something entirely different.
+EOF
+assert_eq "it prints a different fingerprint when a local agent shadows a plugin agent with identical keys" "1" \
+  "$([ "$(fp "$SHADOW_P" "$SHADOW_L")" != "$before_shadow" ] && echo 1 || echo 0)"
+
+# An enrollment set that resolves empty everywhere has a defined fingerprint.
+EMPTY="$(make_plugin_root "$TMP/empty" no-phase.md)"
+efp="$(fp "$EMPTY" "$PROJECT")"
+assert_contains "it produces a defined fingerprint for an empty enrollment set" "$efp" "discover-hooks-fingerprint-v1 "
+assert_eq "it produces a stable fingerprint for an empty enrollment set" "$efp" "$(fp "$EMPTY" "$PROJECT")"
+
+# Path independence: two checkouts of identical content at different paths must
+# agree, or two developers halt each other's runs.
+COPY="$TMP/elsewhere/deeper"
+mkdir -p "$COPY"
+cp -R "$PLUGIN" "$COPY/plugin"
+assert_eq "it produces the same fingerprint for identical content at a different path" \
+  "$base" "$(fp "$COPY/plugin" "$PROJECT")"
+
+# --- --expect ---------------------------------------------------------------
+run_script "$PLUGIN" "$PROJECT" --expect="$base" --hook=post-plan >/dev/null 2>&1
+assert_exit "it exits 0 when expect matches" 0 "$?"
+
+out="$(run_script "$PLUGIN" "$PROJECT" --expect="$hash" --hook=post-plan 2>/dev/null)"; code=$?
+assert_exit "it accepts a bare 64-hex digest for expect" 0 "$code"
+assert_contains "it produces normal output when expect matches" "$out" "alpha"
+
+json="$(run_script "$PLUGIN" "$PROJECT" --expect="$base" --json --hook=post-plan 2>/dev/null)"
+assert_contains "it composes expect with json output" "$json" '"name":"alpha"'
+
+stale="0000000000000000000000000000000000000000000000000000000000000000"
+out="$(run_script "$PLUGIN" "$PROJECT" --expect="$stale" --hook=post-plan 2>/dev/null)"; code=$?
+assert_exit "it exits 4 when expect does not match" 4 "$code"
+assert_empty "it writes nothing to stdout when drift is detected" "$out"
+
+err="$(run_script "$PLUGIN" "$PROJECT" --expect="$stale" --hook=post-plan 2>&1 >/dev/null)"
+assert_contains "it says enrollment changed in the drift message" "$err" "hook enrollment changed since this run started"
+assert_contains "it lists the current enrollment in the drift message" "$err" "alpha (post-plan"
+assert_contains "it names the re-baseline escape hatch in the drift message" "$err" ".hook-fingerprint and re-run to re-baseline"
+
+# A botched write must not masquerade as drift — that halts the run pointing at
+# entirely the wrong cause.
+for bad in "" "not-a-hash" "abc123" "$(printf 'zz%060d' 0)"; do
+  run_script "$PLUGIN" "$PROJECT" --expect="$bad" --hook=post-plan >/dev/null 2>&1
+  assert_exit "it exits 2 rather than 4 for a malformed expect value [$bad]" 2 "$?"
+done
+
+# A future hash-format bump must not brick every existing plan.
+err="$(run_script "$PLUGIN" "$PROJECT" --expect="discover-hooks-fingerprint-v2 $stale" --hook=post-plan 2>&1 >/dev/null)"; code=$?
+assert_exit "it exits 0 on a fingerprint version mismatch instead of reporting drift" 0 "$code"
+assert_contains "it warns that the drift check was skipped on a version mismatch" "$err" "skipping the drift check"
+
+# An invalid agent file is a more urgent report than a changed one.
+BADV="$(make_plugin_root "$TMP/badv" alpha.md bad-mode.md)"
+run_script "$BADV" "$PROJECT" --expect="$stale" --hook=post-plan >/dev/null 2>&1
+assert_exit "it reports an invalid agent file as exit 3 even when drift is also present" 3 "$?"
+
+rm -rf "$TMP"

--- a/tests/test-merge.sh
+++ b/tests/test-merge.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Local-overrides-plugin merge, fatal validation, and the deterministic sort.
+
+TMP="$(new_tmpdir)"
+
+# --- merge keyed on frontmatter name, not filename --------------------------
+PLUGIN="$(make_plugin_root "$TMP/plugin" shadow-plugin.md alpha.md)"
+PROJECT="$(make_project "$TMP/project" shadow-local.md)"
+all="$(run_script "$PLUGIN" "$PROJECT" 2>/dev/null)"
+
+assert_contains "it keys the override on the frontmatter name rather than the filename" \
+  "$(normalize_ws "$all")" "order=90 name=shared-agent mode=batch"
+assert_not_contains "it discards the plugin version entirely rather than merging fields" \
+  "$(run_script "$PLUGIN" "$PROJECT" --hook=post-plan 2>/dev/null)" "shared-agent"
+assert_contains "it keeps plugin agents whose name is not shadowed locally" "$all" "alpha"
+
+count="$(printf '%s\n' "$all" | grep -c 'name=shared-agent')"
+assert_eq "it yields exactly one entry for an overridden name" "1" "$count"
+
+# --- duplicate name inside one directory ------------------------------------
+DUP="$(make_plugin_root "$TMP/dup" dup-a.md dup-b.md)"
+err="$(run_script "$DUP" "$PROJECT" 2>&1 >/dev/null)"; code=$?
+assert_exit "it does not fail on a duplicate name in one directory" 0 "$code"
+assert_contains "it warns about a duplicate name in one directory" "$err" "duplicate name 'dupe'"
+dupcount="$(run_script "$DUP" "$PROJECT" 2>/dev/null | grep -c 'name=dupe')"
+assert_eq "it picks a single deterministic winner for a duplicate name" "1" "$dupcount"
+
+# --- fatal validation -------------------------------------------------------
+BADP="$(make_plugin_root "$TMP/badphase" alpha.md bad-phase-1.md bad-phase-2.md)"
+out="$(run_script "$BADP" "$PROJECT" --hook=post-plan 2>/dev/null)"; code=$?
+assert_exit "it exits 3 when an agent declares a phase outside the 8 known hooks" 3 "$code"
+assert_empty "it writes nothing to stdout when validation fails" "$out"
+
+err="$(run_script "$BADP" "$PROJECT" --hook=post-plan 2>&1 >/dev/null)"
+assert_contains "it names the offending file in the unknown-phase error" "$err" "bad-phase-1.md"
+assert_contains "it names the offending value in the unknown-phase error" "$err" "unknown phase 'execution'"
+assert_contains "it lists the valid phases in the unknown-phase error" "$err" "valid phases: pre-plan post-plan"
+assert_contains "it names the remove-the-phase-key remedy" "$err" "remove its 'phase' key entirely"
+assert_contains "it reports every invalid file before exiting rather than only the first" "$err" "bad-phase-2"
+
+# Validation is global: a bad value in a post-commit agent must abort a
+# pre-plan query, because the earliest report is the cheapest fix.
+BADM="$(make_plugin_root "$TMP/badmode" alpha.md bad-mode.md)"
+run_script "$BADM" "$PROJECT" --hook=pre-plan >/dev/null 2>&1
+assert_exit "it aborts on an invalid agent belonging to a hook other than the one queried" 3 "$?"
+err="$(run_script "$BADM" "$PROJECT" 2>&1 >/dev/null)"
+assert_contains "it exits 3 when an agent declares a mode other than single or batch" "$err" "unknown mode 'batched'"
+assert_contains "it lists the valid modes in the unknown-mode error" "$err" "valid modes: single batch"
+
+# --- sort and tie-break -----------------------------------------------------
+# A clean project: $PROJECT carries shadow-local.md, which also enrolls at
+# pre-commit and would otherwise join the rows under test.
+SORT="$(make_plugin_root "$TMP/sort" apple.md banana.md quoted.md)"
+SORTPROJ="$(make_project "$TMP/sortproject")"
+rows="$(run_script "$SORT" "$SORTPROJ" --hook=pre-commit 2>/dev/null | grep 'order=')"
+assert_eq "it sorts by order ascending" \
+  "quoted # not-a-comment" \
+  "$(printf '%s\n' "$rows" | head -1 | sed 's/.*name=//; s/  *mode=.*//')"
+assert_eq "it tie-breaks equal order by name case-insensitively" \
+  "Apple banana" \
+  "$(printf '%s\n' "$rows" | tail -2 | sed 's/.*name=//; s/  *mode=.*//' | tr '\n' ' ' | sed 's/ $//')"
+
+# Tie-break must not depend on the ambient locale, or a macOS en_US.UTF-8 user
+# and a Linux C user disagree about the pipeline.
+c_order="$(LC_ALL=C run_script "$SORT" "$SORTPROJ" --hook=pre-commit 2>/dev/null)"
+u_order="$(LC_ALL=en_US.UTF-8 run_script "$SORT" "$SORTPROJ" --hook=pre-commit 2>/dev/null)"
+assert_eq "it produces the same tie-break order regardless of the ambient locale" "$c_order" "$u_order"
+
+rm -rf "$TMP"

--- a/tests/test-output.sh
+++ b/tests/test-output.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Human table and --json rendering.
+
+TMP="$(new_tmpdir)"
+PLUGIN="$(make_plugin_root "$TMP/plugin" alpha.md quoted.md)"
+PROJECT="$(make_project "$TMP/project")"
+
+# --- filtered ---------------------------------------------------------------
+out="$(run_script "$PLUGIN" "$PROJECT" --hook=post-plan 2>/dev/null)"
+assert_contains "it prints a header naming the hook" "$out" "# hook: post-plan"
+assert_contains "it prints name order and mode for each resolved agent" \
+  "$(normalize_ws "$out")" "order=10 name=alpha mode=single"
+
+# A Bash call's stdout is visible in the transcript, so a filtered empty result
+# must be ABSOLUTELY silent or the empty-hook rule is violated by the fix.
+out="$(run_script "$PLUGIN" "$PROJECT" --hook=pre-batch 2>/dev/null)"; code=$?
+assert_empty "it prints nothing for a filtered hook with no enrolled agents" "$out"
+assert_exit "it exits 0 when a filtered hook resolves empty" 0 "$code"
+
+# --- unfiltered (by-hand debugging view) ------------------------------------
+all="$(run_script "$PLUGIN" "$PROJECT" 2>/dev/null)"
+hooks="$(printf '%s\n' "$all" | grep -c '^# hook: ')"
+assert_eq "it prints all 8 hooks when no hook filter is given" "8" "$hooks"
+assert_contains "it prints an explicit empty marker in the unfiltered view" "$all" "(empty — no agents enrolled at this hook)"
+assert_eq "it prints the hooks in canonical HOOKS.md order" \
+  "pre-plan post-plan pre-implementation pre-batch post-batch post-implementation pre-commit post-commit" \
+  "$(printf '%s\n' "$all" | sed -n 's/^# hook: //p' | tr '\n' ' ' | sed 's/ $//')"
+
+out="$(run_script "$PLUGIN" "$PROJECT" --hook=post-plan 2>/dev/null)"
+assert_eq "it prints only the requested hook when --hook is given" "1" \
+  "$(printf '%s\n' "$out" | grep -c '^# hook: ')"
+
+# --- json -------------------------------------------------------------------
+json="$(run_script "$PLUGIN" "$PROJECT" --json --hook=post-plan 2>/dev/null)"
+assert_eq "it emits the expected json for a resolved hook" \
+  '{"hooks":{"post-plan":[{"name":"alpha","order":10,"mode":"single"}]}}' "$json"
+
+empty_json="$(run_script "$PLUGIN" "$PROJECT" --json --hook=pre-batch 2>/dev/null)"
+assert_eq "it emits an empty json array for a hook with no enrolled agents" \
+  '{"hooks":{"pre-batch":[]}}' "$empty_json"
+
+full_json="$(run_script "$PLUGIN" "$PROJECT" --json 2>/dev/null)"
+if command -v python3 >/dev/null 2>&1; then
+  if printf '%s' "$full_json" | python3 -m json.tool >/dev/null 2>&1; then
+    _pass "it emits valid json for all 8 hooks"
+  else
+    _fail "it emits valid json for all 8 hooks" "python3 -m json.tool rejected: $full_json"
+  fi
+  keys="$(printf '%s' "$full_json" | python3 -c 'import json,sys; print(len(json.load(sys.stdin)["hooks"]))')"
+  assert_eq "it includes all 8 hooks in unfiltered json" "8" "$keys"
+else
+  _pass "it emits valid json for all 8 hooks (skipped: no python3)"
+  _pass "it includes all 8 hooks in unfiltered json (skipped: no python3)"
+fi
+
+assert_not_contains "it omits the md extension from agent names in json output" "$full_json" ".md"
+
+# Agent names come from user-authored frontmatter, so a quote in a name must
+# not produce malformed JSON.
+QUOTE="$TMP/quote"
+make_plugin_root "$QUOTE" >/dev/null
+cat > "$QUOTE/agents/tricky.md" <<'EOF'
+---
+name: "he said \"hi\" \\ then left"
+phase: post-plan
+order: 5
+mode: single
+---
+EOF
+qjson="$(run_script "$QUOTE" "$PROJECT" --json --hook=post-plan 2>/dev/null)"
+if command -v python3 >/dev/null 2>&1; then
+  if printf '%s' "$qjson" | python3 -m json.tool >/dev/null 2>&1; then
+    _pass "it escapes quotes and backslashes in json output"
+  else
+    _fail "it escapes quotes and backslashes in json output" "rejected: $qjson"
+  fi
+else
+  _pass "it escapes quotes and backslashes in json output (skipped: no python3)"
+fi
+
+rm -rf "$TMP"

--- a/tests/test-parse.sh
+++ b/tests/test-parse.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Frontmatter parsing and enrollment.
+
+TMP="$(new_tmpdir)"
+PLUGIN="$(make_plugin_root "$TMP/plugin" \
+  alpha.md dormant.md no-phase.md documented-example.md quoted.md \
+  defaults.md nonnumeric-order.md body-phase.md no-frontmatter.md \
+  unterminated.md empty.md noname.md crlf.md)"
+PROJECT="$(make_project "$TMP/project")"
+
+all="$(run_script "$PLUGIN" "$PROJECT" 2>/dev/null)"
+json="$(run_script "$PLUGIN" "$PROJECT" --json 2>/dev/null)"
+
+assert_contains "it extracts name phase order and mode from the first frontmatter block" \
+  "$(normalize_ws "$(run_script "$PLUGIN" "$PROJECT" --hook=post-plan 2>/dev/null)")" \
+  "order=10 name=alpha mode=single"
+
+# The single most important assertion in the suite: the bundled
+# standards-enforcer ships with its phase commented out and was made opt-in
+# deliberately. An unanchored match would enable it for every HCF user.
+assert_not_contains "it does not enroll an agent whose phase key is commented out" "$all" "dormant"
+assert_not_contains "it does not match a phase key appearing after the frontmatter block" "$all" "body-phase"
+assert_not_contains "it skips an agent that declares no phase key" "$all" "no-phase"
+assert_not_contains "it skips a file with no frontmatter block" "$all" "no-frontmatter"
+assert_not_contains "it skips a file with an unterminated frontmatter block" "$all" "unterminated"
+
+# A user copy-pasting the documented example must get a working agent.
+assert_contains "it parses the frontmatter example documented in HOOKS.md and README.md" \
+  "$(normalize_ws "$all")" "order=100 name=documented-example mode=single"
+
+assert_contains "it strips surrounding quotes from frontmatter values" "$all" "quoted"
+assert_contains "it preserves a hash character inside a quoted value" "$all" "quoted # not-a-comment"
+assert_contains "it parses an agent file written with CRLF line endings" \
+  "$(normalize_ws "$all")" "order=40 name=crlf mode=single"
+assert_contains "it defaults a missing order to 100 and a missing mode to single" \
+  "$(normalize_ws "$all")" "order=100 name=defaults mode=single"
+assert_contains "it falls back to the filename when no name key is declared" "$all" "noname"
+
+err="$(run_script "$PLUGIN" "$PROJECT" --hook=post-batch 2>&1 >/dev/null)"; code=$?
+assert_exit "it does not fail on a non-numeric order" 0 "$code"
+assert_contains "it warns about a non-numeric order" "$err" "non-numeric order 'high'"
+assert_contains "it treats a non-numeric order as 100" \
+  "$(normalize_ws "$(run_script "$PLUGIN" "$PROJECT" --hook=post-batch 2>/dev/null)")" \
+  "order=100 name=nonnumeric-order"
+
+# Only top-level *.md participates.
+mkdir -p "$PLUGIN/agents/nested"
+cp "$FIXTURES/alpha.md" "$PLUGIN/agents/nested/nested-agent.md"
+cp "$FIXTURES/alpha.md" "$PLUGIN/agents/not-markdown.txt"
+after="$(run_script "$PLUGIN" "$PROJECT" 2>/dev/null)"
+assert_not_contains "it ignores markdown files in subdirectories" "$after" "nested"
+assert_eq "it ignores files that are not markdown" "$all" "$after"
+
+# JSON is a separate rendering path; the dormant case must hold there too.
+assert_not_contains "it keeps a commented-out phase unenrolled in json output too" "$json" "dormant"
+
+rm -rf "$TMP"


### PR DESCRIPTION
Fixes the silent false-empty hook failure reported in #4.

## The problem

`HOOKS.md`'s Discovery Routine was nine prose steps addressed to the model, with no executable backing. Every session improvised its own bash enumeration. One of those improvised scripts hit a parse error:

```
/bin/bash: eval: line 35: syntax error near unexpected token `2'
/bin/bash: eval: line 35: `for f in $LOC/*.md 2>/dev/null; do'
```

Redirections aren't allowed in a `for` word list. The script died between its two sections — the first (plugin agents) had already printed real output, so the partial result was consumed as a complete enumeration and every hook resolved empty.

Nothing surfaced, because `HOOKS.md` mandates total silence for an empty hook. **A crashed discovery and a legitimately empty one were indistinguishable from the outside.** That's why this gets misdiagnosed as bad frontmatter or a plugin that didn't load.

## The fix

`hooks/discover-hooks.sh` is now the single implementation. Both skills run it at all 8 hook call sites and read its output; nothing enumerates agent files by hand.

Failure is loud:

- **Empty hook is now defined as exit 0 with empty stdout.** Every other non-zero exit is an error to report, never a hook to skip silently.
- **An invalid `phase` or `mode` aborts (exit 3)** instead of being warned past. An unknown `phase` meant the agent ran *nowhere* — the same silent non-execution this PR exists to end. Validation is global, so a bad value surfaces at the first hook of a run rather than hours later at commit time.
- **Drift detection** (`--fingerprint` / `--expect=`) halts HCF if agent files change midway through a run, rather than silently executing a different pipeline than the plan was reviewed against.

## Two latent bugs found along the way

**The documented frontmatter example didn't parse.** `HOOKS.md` and `README.md` both show enrollment with trailing comments (`phase: post-plan   # enrolls this agent…`). Under a naive parse that yields an unknown phase and a non-numeric order — so copy-pasting the documented example produced an agent that never ran. Now covered by a test asserting the documented example parses exactly as written.

**CRLF-authored agent files were silently skipped**, since `/^---$/` doesn't match `---\r`.

Anchoring the parser at start-of-line is load-bearing: `standards-enforcer` ships dormant with `# phase:` commented out, and an unanchored match would have enabled it for every HCF user.

## Notes

- **`CLAUDE_PLUGIN_ROOT` is unset in skill-invoked Bash** — it only resolves for `hooks.json` entries. The skills use the base directory the harness states at load instead, so no path inference is involved.
- Adds `tests/` — 97 tests, no dependencies beyond bash/awk/sed/sort/grep, runs on bash 3.2 (stock macOS).
- Adds `.gitignore`; the repo had none.
- **No version bump** — releases are cut separately. The changelog entry sits under `[Unreleased]`.

## Upgrade impact

A project whose agent file has a typo'd `phase` runs today (minus that agent) and will **halt** after upgrading until it's fixed. The error names the file, the bad value, and both remedies — correct it, or remove the `phase` key to unenroll. Only `plan-create` and `plan-orchestrate` call the script; `/project-update` and every other skill stay runnable.

Thanks to @ProxiBlue for the diagnosis and the reference implementation in pb-hcf.

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)