### PR TITLE
chore(release): 2.1.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "hcf",
       "source": "./",
       "description": "Autonomous development orchestration with parallel TDD execution",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "homepage": "https://github.com/markshust/hcf",
       "license": "MIT",
       "keywords": ["tdd", "autonomous", "orchestration", "planning", "agents"]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hcf",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Autonomous development orchestration with parallel TDD execution",
   "author": {
     "name": "Mark Shust",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to HCF are documented here. Format follows [Keep a Changelog
 
 ## [Unreleased]
 
+## [2.1.0] — 2026-07-26
+
 ### Added
 - **`hooks/discover-hooks.sh`** — hook discovery is now a shipped script instead of prose instructions the model executed by improvising a bash glob loop. `plan-create` and `plan-orchestrate` run it at all 8 hook call sites and read its output. Closes [#4](https://github.com/markshust/hcf/issues/4), where an improvised enumeration hit a bash syntax error partway through, its partial output was consumed as complete, and **every hook silently resolved empty** — with no error, because the empty-hook silence rule made the failure invisible.
 - **Run it by hand to debug enrollment.** `$(claude plugin path hcf)/hooks/discover-hooks.sh` prints what is enrolled at every hook; add `--hook=<name>` for one, or `--json` for tooling. This is the fastest answer to "why didn't my agent fire?", which previously had no answer at all — the improvised script no longer existed by the time you asked.
@@ -76,7 +78,8 @@ Initial public release.
 - **GitHub issue linking** — `plan-create` captures issue references (`Closes #N`, `Relates to #N`) and `plan-orchestrate` includes them in PR bodies for auto-close on merge.
 - MIT license.
 
-[Unreleased]: https://github.com/markshust/hcf/compare/hcf--v2.0.0...HEAD
+[Unreleased]: https://github.com/markshust/hcf/compare/hcf--v2.1.0...HEAD
+[2.1.0]: https://github.com/markshust/hcf/compare/hcf--v2.0.0...hcf--v2.1.0
 [2.0.0]: https://github.com/markshust/hcf/compare/hcf--v1.1.1...hcf--v2.0.0
 [1.1.1]: https://github.com/markshust/hcf/compare/hcf--v1.1.0...hcf--v1.1.1
 [1.1.0]: https://github.com/markshust/hcf/compare/hcf--v1.0.0...hcf--v1.1.0


### PR DESCRIPTION
Cuts the 2.1.0 release: promotes `[Unreleased]` to a dated `[2.1.0]` section with its comparison link, and bumps the version in both manifests.

Contains no functional changes — the work itself landed in #5.

## Why minor, not major

The change that could look breaking is that an invalid `phase` or `mode` now **aborts** instead of being warned past. I read that as minor:

- The **frontmatter schema is unchanged** — `phase` was always documented as one of the 8 hook points. What changed is enforcement of an existing rule.
- **No previously-valid configuration becomes invalid.** A file that now halts the run was already misconfigured; the agent simply never ran, silently.
- Nothing was removed, and no shipped default changed. `standards-enforcer` is still dormant, `devils-advocate` still enrolls at `post-plan`.

Practical impact is real and called out prominently in the changelog: a project carrying a typo'd `phase` will halt until it's fixed. The error names the file, the bad value, and both remedies, and only the two planning skills call the script — `/hcf:project-update` and everything else stay runnable.

## Release checklist

- [x] `[Unreleased]` promoted to `[2.1.0] — 2026-07-26`
- [x] Comparison link added; `[Unreleased]` repointed at `hcf--v2.1.0`
- [x] `plugin.json` and `marketplace.json` both at `2.1.0`, JSON valid
- [x] Test suite green (97 passing)
- [ ] `claude plugin tag --push` → `hcf--v2.1.0`
- [ ] Mirror to GitHub Releases with `--latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)