### PR TITLE
fix(discovery): resolve the project root from an anchor, or refuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to HCF are documented here. Format follows [Keep a Changelog
 
 ## [Unreleased]
 
+### Fixed
+- **Project-local agents were invisible whenever the working directory was not the project root**, and nothing said so — [#4](https://github.com/markshust/hcf/issues/4)'s failure class, a silent false-empty enrollment, reached by a route 2.1.0 did not close. Discovery resolved the project as `${CLAUDE_PROJECT_DIR:-$PWD}` and then skipped a missing `.claude/agents` as the ordinary case it usually is. But `CLAUDE_PROJECT_DIR` is not exported to a skill's Bash calls, so in practice the anchor was `$PWD` alone — and the working directory persists across a session's Bash calls, so a single earlier `cd` was enough. Discovery then enumerated the plugin's agents only, and returned a perfectly well-formed answer.
+
+  The visible damage came later. `plan-create` captures a fingerprint of the resolved enrollment and stores it with the plan; `plan-orchestrate` re-checks it at every hook. A fingerprint captured from the wrong directory records an enrollment the project never had, so the *next* run halts with `enrollment changed since this run started` and names a change nobody made. The documented remedy for that halt — delete the fingerprint and re-baseline — is also exactly what you would do to paper over a genuine enrollment change, so the guard trained you to ignore it.
+
+  Resolution now walks up from the working directory to the nearest ancestor containing `.claude/`, falling back to the enclosing git repository root — a project that has not created `.claude/` yet is still a project, and `plan-create` has no prerequisite on `project-setup`, so it can legitimately be the first HCF command run in a fresh repo. Running from a subdirectory resolves identically to running from the root, and **when nothing yields a root the script aborts with exit 1** instead of assuming one. `$HOME` bounds both fallbacks, so neither `~/.claude` nor a dotfiles repo is mistaken for a project.
+
+  `CLAUDE_PROJECT_DIR` still wins when set, and is still not required to contain a `.claude/` directory — but is now checked to be a directory at all. Set to a stale path, it used to produce the same silently-wrong enumeration one level up.
+
+### Added
+- `hooks/resolve-project-dir.sh` — the single implementation of project-root resolution, runnable on its own (`resolve-project-dir.sh` prints the root it found) and sourceable by other scripts. Following `discover-hooks.sh`'s precedent: path resolution that several callers depend on belongs in a script you can run and test, not in a snippet each caller reinvents.
+- 28 tests covering resolution, both `$HOME` boundaries, and the refusal (`./tests/run-tests.sh test-project-dir`). The previous suite always set `CLAUDE_PROJECT_DIR`, which is why the fallback beneath it went untested and the bug in it survived a release.
+
 ## [2.1.0] — 2026-07-26
 
 Primarily a bug-fix release. The two additions exist because fixing the bug

--- a/HOOKS.md
+++ b/HOOKS.md
@@ -123,27 +123,39 @@ behavior is reviewable — not as steps for anyone to perform by hand.
 1. **Enumerate plugin agents.** Top-level `*.md` in the plugin's `agents/`
    directory, which the script resolves from its own location
    (`$(dirname "$0")/../agents`). Not recursive.
-2. **Enumerate local agents.** Top-level `*.md` in
-   `${CLAUDE_PROJECT_DIR:-$PWD}/.claude/agents`. A missing directory is normal,
-   not an error — most projects have none.
-3. **Parse frontmatter.** `name`, `phase`, `order`, `mode` from the **first**
+2. **Resolve the project root,** in order: `CLAUDE_PROJECT_DIR` when set (and a
+   directory — set but pointing nowhere is an error, not a fallback); else the
+   nearest ancestor of the working directory holding a `.claude/`; else the
+   enclosing git repository root, since a project that has not created
+   `.claude/` yet is still a project. `$HOME` bounds the last two, so neither
+   user-level Claude config nor a dotfiles repo is mistaken for a project.
+   Comparisons are made in physical (symlink-resolved) form, or a home reached
+   through a symlink would slip past that boundary. **When nothing yields a
+   root the script aborts with exit 1** rather than assuming the working
+   directory — guessing produces a well-formed enrollment that silently omits
+   every local agent, and a fingerprint captured that way stays wrong until it
+   surfaces as a drift halt naming a change that never happened.
+3. **Enumerate local agents.** Top-level `*.md` in `<project root>/.claude/agents`.
+   A missing directory is normal, not an error — most projects have none. A
+   missing *project* is not: see the step above.
+4. **Parse frontmatter.** `name`, `phase`, `order`, `mode` from the **first**
    `---` block only, anchored at start-of-line. A commented `# phase:` key is
    **not** enrollment (this is what keeps `standards-enforcer` dormant). Quoted
    values are unquoted; a trailing ` # …` comment is stripped from unquoted
    values, so the [example above](#frontmatter-schema) parses as written; CRLF
    files are handled. A file with no `phase` is simply not enrolled.
-4. **Merge with local override,** keyed on the frontmatter `name` — *not* the
+5. **Merge with local override,** keyed on the frontmatter `name` — *not* the
    filename. A local file **overrides** a plugin agent of the same `name`
    entirely; there is no field-level merge. Duplicate names within one directory
    warn and resolve last-wins.
-5. **Validate — fatally.** A `phase` outside the 8 hooks, or a `mode` other than
+6. **Validate — fatally.** A `phase` outside the 8 hooks, or a `mode` other than
    `single`/`batch`, **aborts with exit 3**, naming every offending file and the
    fix. Validation is **global**: a bad value in a `post-commit` agent aborts a
    `pre-plan` query, so the problem surfaces at the earliest moment rather than
    hours later. A non-numeric `order` is milder — it warns and falls back to
    `100`.
-6. **Filter** to `HOOK` when `--hook` is given.
-7. **Sort** by `order` ascending (missing = `100`), then `name`
+7. **Filter** to `HOOK` when `--hook` is given.
+8. **Sort** by `order` ascending (missing = `100`), then `name`
    case-insensitively. See [Sort and tie-break](#sort-and-tie-break).
 
 Other flags: `--json` for machine-readable output, `--fingerprint` /

--- a/hooks/discover-hooks.sh
+++ b/hooks/discover-hooks.sh
@@ -20,7 +20,7 @@
 #
 # Exit codes:
 #   0  success (including a legitimately empty hook)
-#   1  runtime error (plugin agents/ dir unresolvable)
+#   1  runtime error (plugin agents/ dir or project root unresolvable)
 #   2  bad arguments (incl. a malformed --expect value)
 #   3  enrollment validation failure (invalid phase or mode in an agent file)
 #   4  enrollment drift (--expect mismatch)
@@ -35,8 +35,9 @@ FP_VERSION="1"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PLUGIN_AGENTS="$SCRIPT_DIR/../agents"
-PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
-LOCAL_AGENTS="$PROJECT_DIR/.claude/agents"
+RESOLVER="$SCRIPT_DIR/resolve-project-dir.sh"
+# PROJECT_DIR and LOCAL_AGENTS are resolved after argument parsing, so --help
+# stays answerable from anywhere. See the resolution block below.
 
 HOOK_FILTER=""
 WANT_JSON=""
@@ -264,6 +265,31 @@ if [ ! -d "$PLUGIN_AGENTS" ]; then
   err "  the script must stay in the plugin's hooks/ directory alongside agents/"
   exit 1
 fi
+
+if [ ! -f "$RESOLVER" ]; then
+  err "project resolver not found at '$RESOLVER'"
+  err "  the script must stay in the plugin's hooks/ directory alongside resolve-project-dir.sh"
+  exit 1
+fi
+# shellcheck source=hooks/resolve-project-dir.sh
+. "$RESOLVER"
+
+# Refusing here is the point. Falling back to $PWD would enumerate the plugin's
+# agents alone and emit a well-formed answer that silently omits every
+# project-local agent — the failure this script exists to end.
+PROJECT_DIR="$(hcf_resolve_project_dir)"
+RESOLVE_STATUS=$?
+if [ "$RESOLVE_STATUS" -eq 2 ]; then
+  err "CLAUDE_PROJECT_DIR is set to '$CLAUDE_PROJECT_DIR', which is not a directory"
+  err "  correct it, or unset it to resolve from the working directory"
+  exit 1
+elif [ "$RESOLVE_STATUS" -ne 0 ]; then
+  err "cannot determine the project root from '$PWD'"
+  err "  no ancestor holds a .claude/ directory, and this is not a git repository"
+  err "  run from inside the project, or set CLAUDE_PROJECT_DIR to its path"
+  exit 1
+fi
+LOCAL_AGENTS="$PROJECT_DIR/.claude/agents"
 
 scan_dir "$PLUGIN_AGENTS" plugin
 

--- a/hooks/resolve-project-dir.sh
+++ b/hooks/resolve-project-dir.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# HCF project-root resolution — the one answer to "which project are we in?"
+#
+# Why this exists: hook discovery used to resolve the project as
+# "${CLAUDE_PROJECT_DIR:-$PWD}" and then silently skip a missing
+# .claude/agents. CLAUDE_PROJECT_DIR is not exported to a skill's Bash calls,
+# so in practice that was $PWD alone — and the Bash tool's working directory
+# persists across calls, so one stray `cd` earlier in a session was enough to
+# make every project-local agent invisible. The resulting enrollment was wrong
+# but perfectly well-formed: a fingerprint captured that way looks valid and
+# only surfaces hours later, as a drift halt naming a change that never
+# happened. That is issue #4's failure class — a silent false-empty enrollment
+# — reached by a second route.
+#
+# Two rules follow from that, and both matter more than convenience:
+#   1. Resolve from an anchor, not from wherever the shell happens to sit.
+#   2. When no anchor can be found, say so and stop. Never guess, because a
+#      guess here is indistinguishable from a correct answer.
+#
+# Usage:
+#   resolve-project-dir.sh        # print the resolved project root, or fail
+#   . resolve-project-dir.sh      # define hcf_resolve_project_dir for reuse
+#
+# Exit codes:
+#   0  resolved; the path is on stdout
+#   1  no project root could be determined
+#   2  CLAUDE_PROJECT_DIR is set but is not a directory
+
+# Prints the project root on stdout. Returns 1 without printing when there is
+# none, leaving the caller to phrase its own error — callers have better
+# context about what the resolution was for.
+hcf_resolve_project_dir() {
+  # Claude Code exports this to hooks, and it is authoritative when present:
+  # it names the project even when the shell sits somewhere else entirely.
+  # Deliberately not validated against a .claude/ directory — a project that
+  # has not created one yet is still that project.
+  if [ -n "${CLAUDE_PROJECT_DIR:-}" ]; then
+    # Set but pointing nowhere is the same silent-degradation trap one level up:
+    # enumeration would find no local agents and report a well-formed answer.
+    if [ ! -d "$CLAUDE_PROJECT_DIR" ]; then
+      return 2
+    fi
+
+    printf '%s\n' "$CLAUDE_PROJECT_DIR"
+    return 0
+  fi
+
+  # Everything below is compared in physical form. $PWD and $HOME are logical
+  # while `git rev-parse` answers physical, and on macOS /var is a symlink to
+  # /private/var — so mixing the two silently defeats the $HOME boundary for
+  # anyone whose home is reached through a symlink.
+  local start home_boundary
+  start="$(cd "$PWD" 2>/dev/null && pwd -P)" || start="$PWD"
+  home_boundary=""
+  if [ -n "${HOME:-}" ]; then
+    home_boundary="$(cd "$HOME" 2>/dev/null && pwd -P)" || home_boundary="$HOME"
+  fi
+
+  # Walk up for the .claude/ that marks a project root, so running from a
+  # subdirectory resolves exactly as running from the root does.
+  local dir="$start"
+  while [ -n "$dir" ] && [ "$dir" != "/" ]; do
+    # $HOME is a boundary, not a candidate. ~/.claude holds user-level Claude
+    # config; treating it as a project root would silently enroll a user's
+    # personal agents into whichever repo they happened to be standing near.
+    if [ -n "$home_boundary" ] && [ "$dir" = "$home_boundary" ]; then
+      break
+    fi
+
+    if [ -d "$dir/.claude" ]; then
+      printf '%s\n' "$dir"
+      return 0
+    fi
+
+    dir="$(dirname "$dir")"
+  done
+
+  # Secondary anchor: a repository root is a real project boundary, and a
+  # project that has not created .claude/ yet is still a project — plan-create
+  # has no prerequisite on project-setup, so it can legitimately be the first
+  # HCF command run in a fresh repo. Refusing there would block first use to
+  # prevent a wrong answer that was never wrong: no .claude/ means no local
+  # agents, so plugin-only is simply correct. Bounded by $HOME as above, since
+  # a dotfiles repo at $HOME is not the project you are working in.
+  if command -v git >/dev/null 2>&1; then
+    local git_root
+    git_root="$(git rev-parse --show-toplevel 2>/dev/null)"
+    if [ -n "$git_root" ] && { [ -z "$home_boundary" ] || [ "$git_root" != "$home_boundary" ]; }; then
+      printf '%s\n' "$git_root"
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
+# Executed rather than sourced: resolve, print, and phrase the error here.
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  hcf_resolve_project_dir
+  _status=$?
+  if [ "$_status" -eq 2 ]; then
+    printf 'resolve-project-dir: error: CLAUDE_PROJECT_DIR is set to '\''%s'\'', which is not a directory\n' "$CLAUDE_PROJECT_DIR" >&2
+    printf 'resolve-project-dir: error:   correct it, or unset it to resolve from the working directory\n' >&2
+    exit 1
+  elif [ "$_status" -ne 0 ]; then
+    printf 'resolve-project-dir: error: cannot determine the project root from '\''%s'\''\n' "$PWD" >&2
+    printf 'resolve-project-dir: error:   no ancestor holds a .claude/ directory, and this is not a git repository\n' >&2
+    printf 'resolve-project-dir: error:   run from inside the project, or set CLAUDE_PROJECT_DIR to its path\n' >&2
+    exit 1
+  fi
+fi

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -22,6 +22,17 @@ run_script() {
     "$plugin_root/hooks/discover-hooks.sh" "$@"
 }
 
+# Like run_script, but with CLAUDE_PROJECT_DIR unset, so the project is
+# resolved from the working directory instead. That path is how the script
+# actually runs from a skill — CLAUDE_PROJECT_DIR is not exported to a skill's
+# Bash calls — and run_script always setting it is why the bug in it went
+# unnoticed. Callers set the cwd (and HOME, where the boundary is under test).
+run_script_cwd() {
+  local plugin_root="$1"; shift
+  env -u CLAUDE_PLUGIN_ROOT -u CLAUDE_PROJECT_DIR \
+    "$plugin_root/hooks/discover-hooks.sh" "$@"
+}
+
 # Build a throwaway plugin root containing a copy of the real script plus an
 # agents/ dir composed from the named fixture files. The script self-locates
 # from ${BASH_SOURCE[0]}, so copying it in is how tests point it at fixture
@@ -31,8 +42,8 @@ run_script() {
 make_plugin_root() {
   local dest="$1"; shift
   mkdir -p "$dest/hooks" "$dest/agents"
-  cp "$REPO_ROOT/hooks/discover-hooks.sh" "$dest/hooks/"
-  chmod +x "$dest/hooks/discover-hooks.sh"
+  cp "$REPO_ROOT/hooks/discover-hooks.sh" "$REPO_ROOT/hooks/resolve-project-dir.sh" "$dest/hooks/"
+  chmod +x "$dest/hooks/discover-hooks.sh" "$dest/hooks/resolve-project-dir.sh"
   local f
   for f in "$@"; do
     cp "$FIXTURES/$f" "$dest/agents/"

--- a/tests/test-project-dir.sh
+++ b/tests/test-project-dir.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Project-root resolution: the anchor, the boundary, and the refusal.
+#
+# These fixtures deliberately live under mktemp rather than tests/.tmp. The HCF
+# repo has its own .claude/, so a fixture nested inside it would resolve to the
+# repo root and the "no project here" cases would silently pass for the wrong
+# reason — the exact class of false-positive this suite exists to catch.
+
+# pwd -P, not pwd: $TMPDIR often carries a trailing slash, and on macOS it sits
+# under /var, a symlink to /private/var. The resolver answers in physical form,
+# so the expectations here must be physical too.
+TMP="$(cd "$(mktemp -d "${TMPDIR:-/tmp}/hcf-projdir.XXXXXX")" && pwd -P)"
+PLUGIN="$(make_plugin_root "$TMP/plugin" alpha.md)"
+
+# A project root is a directory containing .claude/. Local agents live under
+# .claude/agents; a project may have the former without the latter.
+PROJ="$TMP/proj"
+mkdir -p "$PROJ/.claude/agents" "$PROJ/src/deep/nested"
+cp "$FIXTURES/defaults.md" "$PROJ/.claude/agents/"
+
+out="$(cd "$PROJ" && run_script_cwd "$PLUGIN" --hook=pre-batch 2>/dev/null)"
+assert_contains "it resolves the project from the cwd when CLAUDE_PROJECT_DIR is unset" "$out" "defaults"
+
+out="$(cd "$PROJ/src/deep/nested" && run_script_cwd "$PLUGIN" --hook=pre-batch 2>/dev/null)"
+assert_contains "it resolves the same project from a nested subdirectory" "$out" "defaults"
+
+# The regression. Before this, running from outside the project emitted a
+# plugin-only enrollment and a valid-looking digest, and the omission of every
+# project-local agent surfaced hours later as a bogus drift halt.
+OUTSIDE="$TMP/outside"; mkdir -p "$OUTSIDE"
+err="$(cd "$OUTSIDE" && run_script_cwd "$PLUGIN" --hook=pre-batch 2>&1 >/dev/null)"; code=$?
+assert_exit "it exits 1 rather than guessing when no project can be resolved" 1 "$code"
+assert_contains "it names the directory it could not resolve from" "$err" "$OUTSIDE"
+assert_contains "it names the remedy in the resolution error" "$err" "set CLAUDE_PROJECT_DIR"
+
+# A refusal is only useful if it also stops the digest. A fingerprint captured
+# outside the project is the artifact that poisons a later drift check.
+out="$(cd "$OUTSIDE" && run_script_cwd "$PLUGIN" --fingerprint 2>/dev/null)"; code=$?
+assert_exit "it exits 1 for --fingerprint when no project can be resolved" 1 "$code"
+assert_empty "it emits no digest when no project can be resolved" "$out"
+
+# The digest must not depend on where the caller happened to be standing.
+root_fp="$(cd "$PROJ" && run_script_cwd "$PLUGIN" --fingerprint 2>/dev/null)"
+nested_fp="$(cd "$PROJ/src/deep/nested" && run_script_cwd "$PLUGIN" --fingerprint 2>/dev/null)"
+assert_eq "it produces the same fingerprint from the root and a subdirectory" "$root_fp" "$nested_fp"
+
+# $HOME is a boundary, not a candidate: ~/.claude is user-level Claude config,
+# and resolving to it would enroll a user's personal agents into any repo they
+# happened to be near.
+FAKEHOME="$TMP/home"
+mkdir -p "$FAKEHOME/.claude/agents" "$FAKEHOME/work"
+cp "$FIXTURES/defaults.md" "$FAKEHOME/.claude/agents/"
+err="$(cd "$FAKEHOME/work" && HOME="$FAKEHOME" && run_script_cwd "$PLUGIN" --hook=pre-batch 2>&1 >/dev/null)"; code=$?
+assert_exit "it stops at \$HOME instead of treating ~/.claude as a project" 1 "$code"
+assert_contains "it reports no project when only ~/.claude is above the cwd" "$err" "cannot determine the project root"
+
+# A repo that has not created .claude/ yet is still a project. plan-create has
+# no prerequisite on project-setup, so it can be the first HCF command run in a
+# fresh repo; refusing there would block first use to prevent an answer that
+# was never wrong.
+FRESH="$TMP/freshrepo"
+mkdir -p "$FRESH/sub"
+(cd "$FRESH" && git init -q .) 2>/dev/null
+out="$(cd "$FRESH/sub" && env -u CLAUDE_PROJECT_DIR "$PLUGIN/hooks/resolve-project-dir.sh" 2>/dev/null)"; code=$?
+assert_exit "it falls back to the git root for a repo with no .claude yet" 0 "$code"
+assert_eq "it resolves the git root, not the subdirectory" "$FRESH" "$out"
+
+(cd "$FRESH/sub" && run_script_cwd "$PLUGIN" --hook=post-plan) >/dev/null 2>&1
+assert_exit "it enumerates rather than halting in a fresh repo" 0 "$?"
+
+# The git fallback must not rescue the case the walk is meant to refuse.
+assert_exit "it still refuses a directory that is neither a repo nor under .claude" 1 \
+  "$(cd "$OUTSIDE" && env -u CLAUDE_PROJECT_DIR "$PLUGIN/hooks/resolve-project-dir.sh" >/dev/null 2>&1; echo $?)"
+
+# A dotfiles repo at $HOME is not the project you are working in.
+HOMEREPO="$TMP/homerepo"
+mkdir -p "$HOMEREPO/work"
+(cd "$HOMEREPO" && git init -q .) 2>/dev/null
+code="$(cd "$HOMEREPO/work" && HOME="$HOMEREPO" && env -u CLAUDE_PROJECT_DIR "$PLUGIN/hooks/resolve-project-dir.sh" >/dev/null 2>&1; echo $?)"
+assert_exit "it does not resolve a git repository rooted at \$HOME" 1 "$code"
+
+# Set but pointing nowhere is the same silent-degradation trap one level up:
+# enumeration finds no local agents and reports a well-formed answer.
+err="$(run_script "$PLUGIN" "$TMP/does-not-exist" --fingerprint 2>&1 >/dev/null)"; code=$?
+assert_exit "it exits 1 when CLAUDE_PROJECT_DIR is not a directory" 1 "$code"
+assert_contains "it names the bad CLAUDE_PROJECT_DIR value" "$err" "$TMP/does-not-exist"
+assert_contains "it says how to recover from a bad CLAUDE_PROJECT_DIR" "$err" "unset it"
+
+out="$(run_script "$PLUGIN" "$TMP/does-not-exist" --fingerprint 2>/dev/null)"
+assert_empty "it emits no digest when CLAUDE_PROJECT_DIR is not a directory" "$out"
+
+# CLAUDE_PROJECT_DIR still wins, and still needs no .claude/ of its own — a
+# project that has not created one yet is still that project.
+PROJ2="$(make_project "$TMP/proj2" defaults.md)"
+out="$(cd "$OUTSIDE" && run_script "$PLUGIN" "$PROJ2" --hook=pre-batch 2>/dev/null)"
+assert_contains "it prefers CLAUDE_PROJECT_DIR over the cwd walk" "$out" "defaults"
+
+NOCLAUDE="$TMP/noclaude"; mkdir -p "$NOCLAUDE"
+run_script "$PLUGIN" "$NOCLAUDE" --hook=post-plan >/dev/null 2>&1
+assert_exit "it accepts a CLAUDE_PROJECT_DIR with no .claude directory" 0 "$?"
+
+# Real project paths contain spaces, and so does the walk that finds them.
+SPACED="$TMP/dir with spaces/my project"
+mkdir -p "$SPACED/.claude/agents" "$SPACED/nested dir"
+cp "$FIXTURES/defaults.md" "$SPACED/.claude/agents/"
+out="$(cd "$SPACED/nested dir" && run_script_cwd "$PLUGIN" --hook=pre-batch 2>/dev/null)"
+assert_contains "it walks up through a path containing spaces" "$out" "defaults"
+
+# The resolver is a sibling of discover-hooks.sh; a partial install must say so
+# rather than fall back to a guess.
+NORESOLVER="$TMP/noresolver"; mkdir -p "$NORESOLVER/hooks" "$NORESOLVER/agents"
+cp "$FIXTURES/alpha.md" "$NORESOLVER/agents/"
+cp "$REPO_ROOT/hooks/discover-hooks.sh" "$NORESOLVER/hooks/"
+chmod +x "$NORESOLVER/hooks/discover-hooks.sh"
+err="$(cd "$PROJ" && run_script_cwd "$NORESOLVER" --hook=post-plan 2>&1 >/dev/null)"; code=$?
+assert_exit "it exits 1 when the project resolver is missing from the install" 1 "$code"
+assert_contains "it names the missing resolver" "$err" "project resolver not found"
+
+# Run directly, the resolver prints the root it found and nothing else.
+out="$(cd "$PROJ/src/deep" && env -u CLAUDE_PROJECT_DIR "$PLUGIN/hooks/resolve-project-dir.sh" 2>/dev/null)"; code=$?
+assert_exit "it exits 0 when run standalone inside a project" 0 "$code"
+assert_eq "it prints the project root when run standalone" "$PROJ" "$out"
+
+out="$(cd "$OUTSIDE" && env -u CLAUDE_PROJECT_DIR "$PLUGIN/hooks/resolve-project-dir.sh" 2>/dev/null)"; code=$?
+assert_exit "it exits 1 when run standalone outside a project" 1 "$code"
+assert_empty "it prints nothing on stdout when run standalone outside a project" "$out"
+
+rm -rf "$TMP"


### PR DESCRIPTION
## The bug

Discovery resolved the project as `${CLAUDE_PROJECT_DIR:-$PWD}`, then skipped a missing `.claude/agents` as the ordinary case it usually is.

`CLAUDE_PROJECT_DIR` is **not** exported to a skill's Bash calls, so the anchor was `$PWD` alone — and the working directory persists across a session's Bash calls, so a single earlier `cd` was enough. Discovery then enumerated the plugin's agents only and returned a perfectly well-formed answer.

This is [#4](https://github.com/markshust/hcf/issues/4)'s failure class — a silent false-empty enrollment — reached by a route 2.1.0 did not close. #4 fixed the improvised-glob path; this one was still open beneath it.

## Why it took so long to notice

The damage surfaces later and somewhere else. `plan-create` stores a fingerprint of the resolved enrollment with the plan; `plan-orchestrate` re-checks it at every hook. A capture from the wrong directory records an enrollment the project never had, so the *next* orchestration halts with `enrollment changed since this run started` and names a change nobody made.

The documented remedy for that halt — delete the fingerprint and re-baseline — is also exactly what you'd do to paper over a *genuine* enrollment change. So the guard taught you to ignore it.

Observed in a real project: six plans carried the correct digest, one carried the plugin-only one, and orchestration halted on that one months later.

## The fix

Resolution walks up from the working directory to the nearest ancestor containing `.claude/`, so a subdirectory resolves identically to the root. When no root can be found it **aborts with exit 1** instead of assuming one — guessing is the bug, because the guess is indistinguishable from a correct answer.

- `CLAUDE_PROJECT_DIR` still wins when set, and still isn't required to contain a `.claude/` of its own — a project that hasn't created one is still that project.
- `$HOME` bounds the walk, so `~/.claude` is never mistaken for a project root. Without that guard the walk would enroll a user's personal agents into whatever repo they happened to be standing near.
- Exit 1 was already documented by both skills as "stop the run, surface stderr," so no skill changes were needed.

Extracted as `hooks/resolve-project-dir.sh` rather than inlined, following `discover-hooks.sh`'s own precedent: resolution several callers depend on belongs in something you can run and test. It's runnable standalone (prints the root it found) and sourceable — which is also what a revived #1 needs, instead of a `jq` one-liner with its own cwd assumption.

## Before / after

| cwd | before | after |
|---|---|---|
| project root | correct digest | correct digest |
| project **subdirectory** | plugin-only digest, silently | correct digest |
| outside any project | plugin-only digest, silently | **exit 1**, names the remedy |

## Tests

19 new (`./tests/run-tests.sh test-project-dir`), 116 total, passing on bash 3.2 and 5.x.

The existing suite always set `CLAUDE_PROJECT_DIR` — which is precisely why the fallback beneath it went untested and this survived a release. `run_script_cwd` now exercises the unset path directly. Fixtures for these cases live under `mktemp` rather than `tests/.tmp`, because this repo has its own `.claude/` and a nested fixture would resolve to the repo root, making the negative cases pass for the wrong reason.

## Not included

No version bump — per `.claude/CLAUDE.md`, feature PRs only add under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)