### PR TITLE
feat(plans-dir): make the plans directory configurable via .claude/hcf.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to HCF are documented here. Format follows [Keep a Changelog
 
 ## [Unreleased]
 
+### Added
+- **Configurable plans directory** ([#1](https://github.com/markshust/hcf/pull/1), by [@michielgerritsen](https://github.com/michielgerritsen)). Plans live in `.claude/plans/` unless a project sets `plansDir` in an optional, user-owned `.claude/hcf.json`:
+
+  ```json
+  { "plansDir": "docs/plans" }
+  ```
+
+  No skill creates or modifies that file, `project-setup` never asks about it, and with it absent everything behaves exactly as before. `plansDir` must be relative to the project root; absolute paths and `..` segments are rejected. Changing it once plans exist means moving the folders yourself — HCF does not migrate them, and `project-update` warns when `.claude/plans` still holds plan folders after a move.
+
+  Resolution is `hooks/resolve-plans-dir.sh`, built on 2.1.1's project anchor, so the answer does not depend on the working directory and the `.hook-fingerprint` written beside a plan follows `plansDir` with it. **A malformed value stops the run instead of falling back to the default** — quietly writing plans somewhere the project did not ask for is the failure mode this whole area keeps producing, and the resolver deliberately does not add another instance of it. No `jq` dependency, for the same reason: a missing `jq` would turn a configured `plansDir` into a silent default on Debian minimal and Alpine.
+
+  Subagents stay configuration-unaware. `plan-orchestrate` passes each `tdd-worker` a concrete `## Task File Path`, `plan-create` passes post-plan agents a concrete `## Plan Directory`, and both agents are told never to read `hcf.json` — one resolver runs per skill, so there is no second resolver to drift from the first.
+
 ## [2.1.1] — 2026-08-17
 
 A single bug fix, in the same place 2.1.0 fixed one: the enrollment a run is

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Autonomous development plugin for Claude Code. Define requirements with a PM, th
   - [Skills](#skills)
   - [Outputs](#outputs)
 - [Architecture](#architecture)
+- [Advanced Configuration](#advanced-configuration)
+  - [Plans Directory](#plans-directory)
 - [Design Principles](#design-principles)
 - [Development](#development)
   - [Local Testing](#local-testing)
@@ -77,7 +79,7 @@ The `plan-create` skill activates automatically to:
 - Ask grounded clarifying questions categorized as **must-answer** vs **will-default-if-silent**
 - Break down into tasks with dependencies
 - Write requirements as test descriptions
-- Create `.claude/plans/user-auth/` with task files
+- Create `.claude/plans/user-auth/` with task files (or your configured [plans directory](#plans-directory))
 - Run **post-plan pipeline** agents (devil's advocate by default) to find gaps before execution
 
 After planning completes, you'll be asked:
@@ -264,7 +266,7 @@ Each task follows strict Red → Green → Refactor:
 | `code-standards.md` | Linting, formatting rules |
 | `architecture.md` | Directory structure, patterns |
 
-#### Plans (`.claude/plans/{name}/`)
+#### Plans (`.claude/plans/{name}/`, configurable — see [Plans Directory](#plans-directory))
 
 | File | Purpose |
 |------|---------|
@@ -351,6 +353,47 @@ hcf/
 The `CLAUDE.md` template that `/project-setup` generates for **your** project
 lives inline in `skills/project-setup/SKILL.md` — `.claude/CLAUDE.md` above is
 this repo's own config and has no effect on what users get.
+
+## Advanced Configuration
+
+HCF works with no configuration. Everything below is opt-in, and the defaults
+are what you get by leaving it alone.
+
+### Plans Directory
+
+Plans live in `.claude/plans/` by default. To put them somewhere else — beside
+your other docs, or at the repo root — create `.claude/hcf.json`:
+
+```json
+{
+  "plansDir": "docs/plans"
+}
+```
+
+`plansDir` is a path **relative to the project root**. Absolute paths and any
+`..` segment are rejected, because plan folders belong inside the repo they
+document.
+
+**No skill ever creates or modifies `.claude/hcf.json`.** `/hcf:project-setup`
+does not ask about it and `/hcf:project-update` only validates it if you have
+already written one. Its absence is the normal case, not an incomplete setup.
+
+**A malformed value stops the run rather than falling back.** If `plansDir` is
+absolute, escapes the project, or is set to an empty string, HCF reports it and
+refuses. Quietly writing plans to `.claude/plans` when you asked for
+`docs/plans` would be the worse outcome: you would find out much later, from
+the wrong directory filling up.
+
+**Changing it after plans exist means moving the folders yourself.** HCF does
+not migrate them; `/hcf:project-update` warns when `.claude/plans` still holds
+plan folders after a move. Keep the plans directory git-tracked, since plan
+files are committed alongside the work they describe.
+
+To see what a project resolves to:
+
+```bash
+$(claude plugin path hcf)/hooks/resolve-plans-dir.sh
+```
 
 ## Design Principles
 

--- a/agents/devils-advocate.md
+++ b/agents/devils-advocate.md
@@ -32,11 +32,12 @@ You are a Devil's Advocate architectural reviewer. Your job is to critically ana
 11. **Missing edge cases** — Are error states, empty states, boundary conditions, and concurrent access scenarios covered?
 
 **Process:**
-1. Read ALL task files in the plan directory
-2. Read the `_plan.md` for the overall architecture
-3. Cross-reference against project architecture docs and code standards where relevant
-4. Cross-reference against actual source files where relevant (e.g., verify that targeted methods/classes exist and have the expected signatures)
-5. Write your findings to `.claude/plans/{plan-name}/_devils_advocate.md`
+1. Determine the plan directory: use the path given under the `## Plan Directory` heading of the prompt you received. If no such heading is present (direct or manual invocation), fall back to `.claude/plans/{plan-name}/`. **Never read `.claude/hcf.json`** — the skill that spawned you already resolved the path, and a second resolver is a second thing to drift.
+2. Read ALL task files in the plan directory
+3. Read the `_plan.md` for the overall architecture
+4. Cross-reference against project architecture docs and code standards where relevant
+5. Cross-reference against actual source files where relevant (e.g., verify that targeted methods/classes exist and have the expected signatures)
+6. Write your findings to `{plan directory}/_devils_advocate.md`, using the path from step 1
 
 **Output format for the findings file:**
 ```markdown

--- a/agents/tdd-worker.md
+++ b/agents/tdd-worker.md
@@ -33,11 +33,19 @@ For EACH unchecked requirement in order:
    - Run tests after EACH change
    - Prioritize: eliminate duplication, improve clarity, make dependencies explicit
 
-4. **MARK COMPLETE**: Update the task file
+4. **MARK COMPLETE**: Update the task file (see [Task File](#task-file) for where it is)
    - Change `- [ ]` to `- [x]` for this requirement
    - Add implementation notes if relevant
 
 5. **REPEAT**: Move to next unchecked requirement
+
+## Task File
+
+Read your task file from the concrete path given under the `## Task File Path` heading of the prompt you received. Use that path for everything: reading requirements, marking checkboxes `[x]`, and appending implementation notes.
+
+If no `## Task File Path` heading is present (direct or manual invocation), locate the task file under the current plan directory instead.
+
+**Never read `.claude/hcf.json`.** The plans directory is configurable, but resolving it is the orchestrator's job — it hands you a finished path precisely so that a second resolver cannot drift from the first.
 
 ## Critical TDD Rules
 

--- a/hooks/resolve-plans-dir.sh
+++ b/hooks/resolve-plans-dir.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# HCF plans-directory resolution — where this project keeps its plan folders.
+#
+# Defaults to <project>/.claude/plans. A project may override it with an
+# optional, user-owned .claude/hcf.json:
+#
+#   { "plansDir": "docs/plans" }
+#
+# No skill creates or modifies that file. Its absence is the normal case.
+#
+# Two deliberate departures from a naive one-liner, both the same lesson this
+# repo keeps relearning (see issue #4 and the 2.1.1 fix):
+#
+#   1. No `jq`. A `jq ... || echo <default>` pipeline turns a missing jq — the
+#      norm on Debian minimal and Alpine — into a silent fallback: you set
+#      plansDir, you get .claude/plans, and nothing says why.
+#   2. A malformed plansDir is an error, not a fallback. Writing plans to a
+#      directory the project did not ask for is worse than refusing, and it
+#      matches how an invalid `phase` already aborts discovery.
+#
+# The project root comes from resolve-project-dir.sh, so the answer does not
+# depend on the working directory. Output is absolute for the same reason:
+# callers pass it to subagents whose cwd is not knowable from here.
+#
+# Usage:
+#   resolve-plans-dir.sh          # print the absolute plans directory
+#   . resolve-plans-dir.sh        # define hcf_resolve_plans_dir
+#
+# Exit codes:
+#   0  resolved; the absolute path is on stdout
+#   1  unresolvable project root, or an invalid plansDir value
+
+HCF_PLANS_DIR_DEFAULT=".claude/plans"
+
+_hcf_plans_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ ! -f "$_hcf_plans_script_dir/resolve-project-dir.sh" ]; then
+  printf 'resolve-plans-dir: error: resolve-project-dir.sh not found alongside this script\n' >&2
+  return 1 2>/dev/null || exit 1
+fi
+# shellcheck source=hooks/resolve-project-dir.sh
+. "$_hcf_plans_script_dir/resolve-project-dir.sh"
+
+# Reads the plansDir value out of a flat JSON object without a JSON parser.
+# Deliberately narrow: one key, a string value, no escapes. Anything it cannot
+# read is reported by the caller as absent, which falls back to the default.
+#
+# Line-oriented, so it does not understand nesting: a plansDir buried inside
+# another object would be read as if top-level. hcf.json is a flat file the user
+# writes by hand and nesting this key means nothing, so that is a documented
+# limit rather than a reason to put a JSON parser in bash. Duplicate keys take
+# the last, and a padded value keeps its padding — both match what `jq` returns.
+hcf_read_plans_dir_key() {
+  sed -n 's/.*"plansDir"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$1" 2>/dev/null | head -1
+}
+
+# Prints the absolute plans directory on stdout. Returns non-zero with a
+# message on stderr when the project root or the configured value is unusable.
+hcf_resolve_plans_dir() {
+  local project status config value
+
+  project="$(hcf_resolve_project_dir)"
+  status=$?
+  if [ "$status" -eq 2 ]; then
+    printf 'resolve-plans-dir: error: CLAUDE_PROJECT_DIR is set to '\''%s'\'', which is not a directory\n' "${CLAUDE_PROJECT_DIR:-}" >&2
+    return 1
+  elif [ "$status" -ne 0 ]; then
+    printf 'resolve-plans-dir: error: cannot determine the project root from '\''%s'\''\n' "$PWD" >&2
+    printf 'resolve-plans-dir: error:   run from inside the project, or set CLAUDE_PROJECT_DIR to its path\n' >&2
+    return 1
+  fi
+
+  config="$project/.claude/hcf.json"
+  value=""
+
+  if [ -f "$config" ]; then
+    # Absent key and unreadable value are the same case on purpose: fall back
+    # quietly. A present-but-empty value is a typo, and is reported below.
+    if grep -q '"plansDir"' "$config" 2>/dev/null; then
+      value="$(hcf_read_plans_dir_key "$config")"
+      if [ -z "$value" ]; then
+        printf 'resolve-plans-dir: error: '\''%s'\'' sets an empty plansDir\n' "$config" >&2
+        printf 'resolve-plans-dir: error:   give it a relative path, or remove the key to use %s\n' "$HCF_PLANS_DIR_DEFAULT" >&2
+        return 1
+      fi
+    fi
+  fi
+
+  if [ -z "$value" ]; then
+    value="$HCF_PLANS_DIR_DEFAULT"
+  fi
+
+  # Containment: the plans directory belongs to the project. Escaping it would
+  # scatter plan folders outside the repo they document.
+  case "$value" in
+    /*)
+      printf 'resolve-plans-dir: error: plansDir '\''%s'\'' must be relative to the project root, not absolute\n' "$value" >&2
+      printf 'resolve-plans-dir: error:   set it in %s\n' "$config" >&2
+      return 1
+      ;;
+    ..|../*|*/..|*/../*)
+      printf 'resolve-plans-dir: error: plansDir '\''%s'\'' must not contain a '\''..'\'' segment\n' "$value" >&2
+      printf 'resolve-plans-dir: error:   set it in %s\n' "$config" >&2
+      return 1
+      ;;
+  esac
+
+  printf '%s\n' "$project/$value"
+}
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  hcf_resolve_plans_dir || exit 1
+fi

--- a/skills/plan-create/SKILL.md
+++ b/skills/plan-create/SKILL.md
@@ -133,17 +133,25 @@ If the branch already exists (resuming a plan), check it out instead:
 git checkout feature/{plan-name}
 ```
 
-**Create plan directory:**
+**Resolve the plans directory,** once, and reuse `$PLANS_DIR` for every path below. It is `.claude/plans` unless the project overrides it in `.claude/hcf.json` (see [Plans Directory](#plans-directory) in the README). The script answers with an absolute path resolved from the project root, so the result does not depend on the working directory:
+
 ```bash
-mkdir -p .claude/plans/{plan-name}
+PLANS_DIR="$("{skill-base-dir}/../../hooks/resolve-plans-dir.sh")" || exit 1
 ```
 
-Use a kebab-case name derived from the feature (e.g., `user-authentication`, `payment-processing`).
+**Never substitute a hand-written `jq` line or a literal `.claude/plans`.** A non-zero exit means the project root or the configured value is unusable; surface the script's stderr verbatim and stop rather than falling back to the default — writing plans somewhere the project did not ask for is the failure this indirection exists to prevent.
+
+**Create plan directory:**
+```bash
+mkdir -p "$PLANS_DIR/{plan-name}"
+```
+
+Use a kebab-case name derived from the feature (e.g., `user-authentication`, `payment-processing`). Quote every path built from `$PLANS_DIR` — a configured directory may contain spaces.
 
 **Record the enrollment fingerprint** so `plan-orchestrate` can detect that hook enrollment changed between planning and execution. Write it by **redirecting a fresh invocation** — do not re-type the value captured at Phase 0:
 
 ```bash
-"{skill-base-dir}/../../hooks/discover-hooks.sh" --fingerprint > .claude/plans/{plan-name}/.hook-fingerprint
+"{skill-base-dir}/../../hooks/discover-hooks.sh" --fingerprint > "$PLANS_DIR/{plan-name}/.hook-fingerprint"
 ```
 
 The file holds exactly that one line and nothing else — no heading, no comment, no explanation. Writing it as a redirect rather than transcribing a remembered value is deliberate: Phases 1–2 are a long interactive stretch, and a value carried across them is exactly what gets lost and then invented.
@@ -294,13 +302,22 @@ On **exit 0 with output**, **PRINT that output verbatim** before spawning anythi
 **4. Spawn each agent in the resolved order**, sequentially:
 
 Use the Agent tool with `subagent_type="{agent-name}"`. The subagent prompt **must** include:
-1. The plan name (so it knows the plan directory path).
-2. The project's architecture context, pasted verbatim — do **not** summarize:
+1. The plan name.
+2. The **resolved** plan directory, so the agent never has to read `hcf.json` or guess a default:
+
+```
+## Plan Directory
+$PLANS_DIR/{plan-name}
+```
+
+3. The project's architecture context, pasted verbatim — do **not** summarize:
 
 ```
 ## Project Architecture
 {paste the COMPLETE content of <architecture> verbatim}
 ```
+
+Pass the concrete path, not the literal `$PLANS_DIR`. Subagents stay configuration-unaware by design: one resolver runs here, and every agent is handed a finished path.
 
 **5. After each subagent completes**, read any updated plan files to prepare the recap for the user.
 
@@ -360,7 +377,7 @@ Once approved:
 ```
 Plan created: {plan-name}
 
-Location: .claude/plans/{plan-name}/
+Location: $PLANS_DIR/{plan-name}/
 Total tasks: {N}
 Independent tasks (batch 1): {count of tasks with no dependencies}
 ```

--- a/skills/plan-orchestrate/SKILL.md
+++ b/skills/plan-orchestrate/SKILL.md
@@ -20,13 +20,23 @@ Example: `plan-orchestrate user-auth`
 
 ## Prerequisites
 
-1. Plan must exist at `.claude/plans/{plan-name}/`
+**First, resolve the plans directory,** once, and reuse `$PLANS_DIR` for every path below. It is `.claude/plans` unless the project overrides it in `.claude/hcf.json` (see [Plans Directory](#plans-directory) in the README). The script answers with an absolute path resolved from the project root, so the result does not depend on the working directory:
+
+```bash
+PLANS_DIR="$("{skill-base-dir}/../../hooks/resolve-plans-dir.sh")" || exit 1
+```
+
+**Never substitute a hand-written `jq` line or a literal `.claude/plans`.** A non-zero exit means the project root or the configured value is unusable; surface the script's stderr verbatim and stop. Quote every path built from `$PLANS_DIR` — a configured directory may contain spaces.
+
+Then:
+
+1. Plan must exist at `$PLANS_DIR/{plan-name}/`
 2. Project must be configured (`.claude/testing.md` exists)
 3. Plan status must be `ready` or `in_progress`
 
 Check prerequisites:
 ```bash
-ls .claude/plans/{plan-name}/_plan.md .claude/testing.md 2>/dev/null
+ls "$PLANS_DIR/{plan-name}/_plan.md" .claude/testing.md 2>/dev/null
 ```
 
 If not found, output error and stop.
@@ -85,8 +95,8 @@ Before starting execution, check if the ralph-wiggum plugin is installed by look
 ### Step 1: Load Plan Context
 
 Read plan files:
-- `.claude/plans/{plan-name}/_plan.md` - Plan overview
-- `.claude/plans/{plan-name}/*.md` - All task files (excluding _plan.md)
+- `$PLANS_DIR/{plan-name}/_plan.md` - Plan overview
+- `$PLANS_DIR/{plan-name}/*.md` - All task files (excluding _plan.md)
 
 Note: Testing and code standards are auto-included above.
 
@@ -102,19 +112,19 @@ Build a dependency graph as a data structure.
 ### Step 2: Update Plan Status
 
 If plan status is `ready`, change to `in_progress`:
-- Edit `.claude/plans/{plan-name}/_plan.md`
+- Edit `$PLANS_DIR/{plan-name}/_plan.md`
 - Set `## Status` to `in_progress`
 
 **Establish the run fingerprint.** Every hook call below passes this back via
 `--expect=`, so that agent files changing mid-run halt the orchestration rather
 than silently swapping the pipeline. Read
-`.claude/plans/{plan-name}/.hook-fingerprint` and handle three distinct states —
+`$PLANS_DIR/{plan-name}/.hook-fingerprint` and handle three distinct states —
 conflating them is the mistake to avoid:
 
 | State | Action |
 |-------|--------|
 | **Present and parseable** (one line: `discover-hooks-fingerprint-v1 <64-hex>`) | Use it as `$RUN_FINGERPRINT`. Pass the file's contents **verbatim** — do not trim, reformat, or re-derive them. |
-| **Missing** | Not an error. Plans created before this feature have none. Capture one and write it to the plan directory so a resumed run is covered too, then continue: `"{skill-base-dir}/../../hooks/discover-hooks.sh" --fingerprint > .claude/plans/{plan-name}/.hook-fingerprint` |
+| **Missing** | Not an error. Plans created before this feature have none. Capture one and write it to the plan directory so a resumed run is covered too, then continue: `"{skill-base-dir}/../../hooks/discover-hooks.sh" --fingerprint > "$PLANS_DIR/{plan-name}/.hook-fingerprint"` |
 | **Present but unparseable** (empty, truncated, prose, wrong length) | **Halt.** Do not silently recapture — that would mask a botched write. Tell the user to delete the file to re-baseline. |
 
 **Never reconstruct, abbreviate, or recall a fingerprint from memory.** It is
@@ -305,10 +315,10 @@ exit stops the run before the commit** — see [Hook Discovery](#hook-discovery)
 First, update `_plan.md` status to `completed`. Then stage and commit everything together in a **single commit**:
 ```bash
 # 1. Update plan status BEFORE committing
-# (edit .claude/plans/{plan-name}/_plan.md — set Status to "completed")
+# (edit $PLANS_DIR/{plan-name}/_plan.md — set Status to "completed")
 
 # 2. Stage everything: implementation + hook agent fixes + plan files (including updated status)
-git add -A .claude/plans/{plan-name}/
+git add -A "$PLANS_DIR/{plan-name}/"
 git add -A
 git commit -m "feat({plan-name}): {plan title summary}"
 ```
@@ -376,6 +386,9 @@ All Task tool calls MUST be made in a SINGLE message to enable parallel executio
 > Do NOT summarize. Subagents have no access to CLAUDE.md or project files beyond what you provide.**
 
 ```markdown
+## Task File Path
+{the concrete resolved path, e.g. $PLANS_DIR/{plan-name}/{task-file}.md}
+
 ## Project Testing Configuration
 {paste the COMPLETE content of <testing> verbatim — do NOT summarize}
 
@@ -387,6 +400,8 @@ All Task tool calls MUST be made in a SINGLE message to enable parallel executio
 ```
 
 The tdd-worker agent already has all TDD methodology and rules. The prompt needs the project-specific configuration and task details since subagents do not inherit CLAUDE.md context.
+
+Pass the **concrete** path under `## Task File Path`, not the literal `$PLANS_DIR` — the worker marks checkboxes and appends implementation notes there, and it must never read `.claude/hcf.json` or assume a default to find it. One resolver runs in this skill; every subagent is handed a finished path.
 
 ### Step 6: Collect Results
 

--- a/skills/project-setup/SKILL.md
+++ b/skills/project-setup/SKILL.md
@@ -273,6 +273,8 @@ Tell the user:
 > To add your own gate, drop an agent file in `.claude/agents/` and give it a `phase` (one of the 8 hook points). A local agent with the same `name` overrides the plugin's. See `HOOKS.md` for the full hook list and frontmatter schema.
 > To see what is currently enrolled at each hook, run `$(claude plugin path hcf)/hooks/discover-hooks.sh` — that is the fastest answer whenever an agent doesn't fire.
 
+> **Advanced configuration note:** `.claude/hcf.json` is an optional, user-owned file (its only key today is `plansDir`). Setup never creates it, never modifies it, and never asks about it. If one already exists, leave it exactly as it is. Its absence is the normal case — do not mention it to the user during setup.
+
 **Create `CLAUDE.md` in project root:**
 
 This file provides always-on context for every Claude session. Keep it concise (~30-50 lines).

--- a/skills/project-update/SKILL.md
+++ b/skills/project-update/SKILL.md
@@ -115,6 +115,29 @@ Also scan `CLAUDE.md` for any **stale reference to `pipeline.md`** — either th
 
 Note any missing references.
 
+### Step 5b: Validate `.claude/hcf.json` (only if present)
+
+`.claude/hcf.json` is an optional, user-owned advanced config file. **Its absence is the normal case and must never be flagged, nor prompt a suggestion to create one.** Never create or modify it — this step only reports.
+
+If the file exists, run the resolver and let it do the judging rather than re-deriving the rules here:
+
+```bash
+"{skill-base-dir}/../../hooks/resolve-plans-dir.sh"
+```
+
+- **Exit 0** — the plans directory is valid. Record ✓ with the resolved path.
+- **Non-zero** — surface the script's stderr verbatim as a ⚠. It already names the offending value and the fix (absolute path, `..` segment, or an empty value). Do not paraphrase it, and do not attempt a repair: the correct value is the user's to choose.
+
+Then two checks the resolver cannot make, because both are about the project rather than the config:
+
+**Check A: the directory exists.** If resolution succeeded but the resolved directory does not exist, add:
+> ⚠ `.claude/hcf.json` — `plansDir` resolves to "{path}", which does not exist. Create it, or correct the value.
+
+**Check B: plans left behind by a move.** If resolution succeeded and the resolved directory is *not* `.claude/plans`, check whether `.claude/plans` still contains subdirectories. If it does, add:
+> ⚠ `.claude/hcf.json` — `plansDir` points at "{path}" but `.claude/plans` still contains plan folders. HCF does not migrate them; move them, or delete them if they are finished.
+
+All three findings use ⚠: none is auto-fixable, and each needs a decision only the user can make.
+
 ### Step 6: Report and Confirm
 
 Output a summary of everything found, using ✓ for current items, ✗ for items that need fixing, and ⚠ for items that need user attention:

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -42,8 +42,10 @@ run_script_cwd() {
 make_plugin_root() {
   local dest="$1"; shift
   mkdir -p "$dest/hooks" "$dest/agents"
-  cp "$REPO_ROOT/hooks/discover-hooks.sh" "$REPO_ROOT/hooks/resolve-project-dir.sh" "$dest/hooks/"
-  chmod +x "$dest/hooks/discover-hooks.sh" "$dest/hooks/resolve-project-dir.sh"
+  cp "$REPO_ROOT/hooks/discover-hooks.sh" "$REPO_ROOT/hooks/resolve-project-dir.sh" \
+    "$REPO_ROOT/hooks/resolve-plans-dir.sh" "$dest/hooks/"
+  chmod +x "$dest/hooks/discover-hooks.sh" "$dest/hooks/resolve-project-dir.sh" \
+    "$dest/hooks/resolve-plans-dir.sh"
   local f
   for f in "$@"; do
     cp "$FIXTURES/$f" "$dest/agents/"

--- a/tests/test-plans-dir.sh
+++ b/tests/test-plans-dir.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Plans-directory resolution: the default, the override, and what it refuses.
+#
+# Fixtures live under mktemp for the same reason as test-project-dir.sh: this
+# repo has its own .claude/, so a fixture nested inside it would resolve to the
+# repo root and the negative cases would pass for the wrong reason.
+
+PTMP="$(cd "$(mktemp -d "${TMPDIR:-/tmp}/hcf-plansdir.XXXXXX")" && pwd -P)"
+PPLUGIN="$(make_plugin_root "$PTMP/plugin" alpha.md)"
+RESOLVE="$PPLUGIN/hooks/resolve-plans-dir.sh"
+
+# A project with no hcf.json is the normal case, not a configured one.
+PLAIN="$PTMP/plain"; mkdir -p "$PLAIN/.claude" "$PLAIN/sub"
+out="$(cd "$PLAIN" && env -u CLAUDE_PROJECT_DIR "$RESOLVE" 2>/dev/null)"; code=$?
+assert_exit "it exits 0 for a project with no hcf.json" 0 "$code"
+assert_eq "it defaults to .claude/plans" "$PLAIN/.claude/plans" "$out"
+
+# The whole point of resolving from an anchor: the answer cannot depend on
+# where the caller was standing.
+out="$(cd "$PLAIN/sub" && env -u CLAUDE_PROJECT_DIR "$RESOLVE" 2>/dev/null)"
+assert_eq "it returns the same directory from a subdirectory" "$PLAIN/.claude/plans" "$out"
+
+# The feature itself.
+CONF="$PTMP/configured"; mkdir -p "$CONF/.claude" "$CONF/nested/deeper"
+printf '{\n  "plansDir": "docs/plans"\n}\n' > "$CONF/.claude/hcf.json"
+out="$(cd "$CONF" && env -u CLAUDE_PROJECT_DIR "$RESOLVE" 2>/dev/null)"; code=$?
+assert_exit "it exits 0 for a configured plansDir" 0 "$code"
+assert_eq "it honors plansDir from hcf.json" "$CONF/docs/plans" "$out"
+
+out="$(cd "$CONF/nested/deeper" && env -u CLAUDE_PROJECT_DIR "$RESOLVE" 2>/dev/null)"
+assert_eq "it honors plansDir from a subdirectory too" "$CONF/docs/plans" "$out"
+
+# hcf.json is user-authored, so formatting varies.
+printf '{"plansDir":"plans"}' > "$CONF/.claude/hcf.json"
+out="$(cd "$CONF" && env -u CLAUDE_PROJECT_DIR "$RESOLVE" 2>/dev/null)"
+assert_eq "it reads a minified single-line hcf.json" "$CONF/plans" "$out"
+
+printf '{\n  "somethingElse": true,\n  "plansDir"  :   "docs/plans"  ,\n  "other": 1\n}\n' > "$CONF/.claude/hcf.json"
+out="$(cd "$CONF" && env -u CLAUDE_PROJECT_DIR "$RESOLVE" 2>/dev/null)"
+assert_eq "it reads plansDir amid other keys and loose spacing" "$CONF/docs/plans" "$out"
+
+# A file with no plansDir key is not a configured project.
+printf '{\n  "somethingElse": true\n}\n' > "$CONF/.claude/hcf.json"
+out="$(cd "$CONF" && env -u CLAUDE_PROJECT_DIR "$RESOLVE" 2>/dev/null)"; code=$?
+assert_exit "it exits 0 when hcf.json omits plansDir" 0 "$code"
+assert_eq "it falls back to the default when hcf.json omits plansDir" "$CONF/.claude/plans" "$out"
+
+# Refusals. A bad value writes plan folders somewhere the project never asked
+# for, so it stops rather than falling back — the same call 2.1.0 made for an
+# invalid `phase`.
+printf '{"plansDir": "/etc/plans"}' > "$CONF/.claude/hcf.json"
+err="$(cd "$CONF" && env -u CLAUDE_PROJECT_DIR "$RESOLVE" 2>&1 >/dev/null)"; code=$?
+assert_exit "it exits 1 on an absolute plansDir" 1 "$code"
+assert_contains "it says an absolute plansDir must be relative" "$err" "must be relative to the project root"
+
+out="$(cd "$CONF" && env -u CLAUDE_PROJECT_DIR "$RESOLVE" 2>/dev/null)"
+assert_empty "it prints no path on an absolute plansDir" "$out"
+
+printf '{"plansDir": "../outside/plans"}' > "$CONF/.claude/hcf.json"
+err="$(cd "$CONF" && env -u CLAUDE_PROJECT_DIR "$RESOLVE" 2>&1 >/dev/null)"; code=$?
+assert_exit "it exits 1 on a plansDir that escapes the project" 1 "$code"
+assert_contains "it names the .. segment as the problem" "$err" "must not contain a '..' segment"
+
+printf '{"plansDir": "docs/../../plans"}' > "$CONF/.claude/hcf.json"
+code="$(cd "$CONF" && env -u CLAUDE_PROJECT_DIR "$RESOLVE" >/dev/null 2>&1; echo $?)"
+assert_exit "it exits 1 on a .. segment in the middle of the path" 1 "$code"
+
+printf '{"plansDir": ""}' > "$CONF/.claude/hcf.json"
+err="$(cd "$CONF" && env -u CLAUDE_PROJECT_DIR "$RESOLVE" 2>&1 >/dev/null)"; code=$?
+assert_exit "it exits 1 on an empty plansDir" 1 "$code"
+assert_contains "it distinguishes an empty plansDir from an absent one" "$err" "sets an empty plansDir"
+
+# A directory named with spaces is ordinary on macOS, and was the bug Michiel's
+# original `mkdir -p $PLANS_DIR/...` would have hit unquoted.
+printf '{"plansDir": "my docs/my plans"}' > "$CONF/.claude/hcf.json"
+out="$(cd "$CONF" && env -u CLAUDE_PROJECT_DIR "$RESOLVE" 2>/dev/null)"; code=$?
+assert_exit "it exits 0 for a plansDir containing spaces" 0 "$code"
+assert_eq "it returns a plansDir containing spaces intact" "$CONF/my docs/my plans" "$out"
+
+# Resolution inherits the project anchor, so it inherits its refusal too.
+OUT2="$PTMP/outside"; mkdir -p "$OUT2"
+err="$(cd "$OUT2" && env -u CLAUDE_PROJECT_DIR "$RESOLVE" 2>&1 >/dev/null)"; code=$?
+assert_exit "it exits 1 when no project root can be resolved" 1 "$code"
+assert_contains "it reports the unresolvable project root" "$err" "cannot determine the project root"
+
+# CLAUDE_PROJECT_DIR names the project; the config is read from there, not cwd.
+out="$(cd "$OUT2" && env -u CLAUDE_PLUGIN_ROOT CLAUDE_PROJECT_DIR="$PLAIN" "$RESOLVE" 2>/dev/null)"
+assert_eq "it reads the config from CLAUDE_PROJECT_DIR, not the cwd" "$PLAIN/.claude/plans" "$out"
+
+err="$(cd "$PLAIN" && env -u CLAUDE_PLUGIN_ROOT CLAUDE_PROJECT_DIR="$PTMP/nope" "$RESOLVE" 2>&1 >/dev/null)"; code=$?
+assert_exit "it exits 1 when CLAUDE_PROJECT_DIR is not a directory" 1 "$code"
+assert_contains "it names the bad CLAUDE_PROJECT_DIR" "$err" "not a directory"
+
+# A partial install must say so rather than guess.
+NOPROJ="$PTMP/noproj"; mkdir -p "$NOPROJ/hooks" "$NOPROJ/agents"
+cp "$REPO_ROOT/hooks/resolve-plans-dir.sh" "$NOPROJ/hooks/"
+chmod +x "$NOPROJ/hooks/resolve-plans-dir.sh"
+err="$(cd "$PLAIN" && env -u CLAUDE_PROJECT_DIR "$NOPROJ/hooks/resolve-plans-dir.sh" 2>&1 >/dev/null)"; code=$?
+assert_exit "it exits 1 when resolve-project-dir.sh is missing" 1 "$code"
+assert_contains "it names the missing project resolver" "$err" "resolve-project-dir.sh not found"
+
+rm -rf "$PTMP"


### PR DESCRIPTION
Supersedes #1. Closes #1.

Carries forward @michielgerritsen's feature on current `main`, since his branch predates 2.0.0 and 2.1.0 and is `CONFLICTING`. He's credited as co-author on the commit.

## What ships

Plans live in `.claude/plans/` unless a project sets `plansDir` in an optional, user-owned `.claude/hcf.json`:

```json
{ "plansDir": "docs/plans" }
```

No skill creates or modifies that file, `project-setup` never asks about it, and with it absent nothing changes.

## What is kept from #1

The design decisions, which were better than what I'd have reached for:

- Opt-in, defaults untouched, no skill authoring the file.
- **Subagents stay configuration-unaware.** `plan-orchestrate` passes each `tdd-worker` a concrete `## Task File Path`; `plan-create` passes post-plan agents a concrete `## Plan Directory`; both agents are told never to read `hcf.json`, with a documented fallback for direct invocation. One resolver runs per skill, so there is no second resolver to drift from the first.
- Containment: relative paths only, `..` rejected.
- `project-update` validates an existing file and never auto-fixes it.

## What changed, and why

**No `jq`** — [as requested](https://github.com/markshust/hcf/pull/1#issuecomment). `jq ... || echo ".claude/plans"` turns a missing `jq` into a silent fallback: you set `plansDir`, you get the default, and nothing tells you why. Current macOS ships `jq`; Debian minimal and Alpine don't. The `plansDir` value is now read with `sed`, in keeping with the suite's zero-dependency rule.

**A malformed value stops the run instead of falling back.** #1 specified a silent fallback for an absolute path or a `..` segment. That is the same failure class 2.1.0 and 2.1.1 were both spent eliminating — writing plans somewhere the project did not ask for is worse than refusing, and it matches how an invalid `phase` already aborts discovery. An empty `plansDir` is likewise reported rather than defaulted, and is distinguished from an absent key.

**Resolution is anchored, not cwd-relative.** #1's snippet read `.claude/hcf.json` as a relative path, which inherits exactly the bug 2.1.1 just fixed one level up: run from a subdirectory and the config silently isn't found. `hooks/resolve-plans-dir.sh` builds on `resolve-project-dir.sh` and answers with an absolute path, so the config is read from the project regardless of where the shell sits — and subagents receive a path that doesn't depend on their cwd either.

**The fingerprint follows `plansDir`.** `.hook-fingerprint` lives inside the plan directory, so 2.1.0's drift detection breaks for precisely the people who enable this feature unless it moves too. #1 predates that file. Both skills now write and read it under `$PLANS_DIR`.

**Paths are quoted throughout** — `mkdir -p $PLANS_DIR/{plan-name}` breaks on `docs/my plans`.

## Tests

27 new in `test-plans-dir` (152 total), green on bash 3.2 and 5.x: the default, the override, subdirectory invariance, minified and loosely-spaced JSON, a key-less file, every refusal, spaces in the configured path, and a partial install missing the project resolver.

```bash
$(claude plugin path hcf)/hooks/resolve-plans-dir.sh   # what does this project resolve to?
```

## Not included

No version bump — feature PRs only add under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)