### PR TITLE
release: 2.2.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "hcf",
       "source": "./",
       "description": "Autonomous development orchestration with parallel TDD execution",
-      "version": "2.1.1",
+      "version": "2.2.0",
       "homepage": "https://github.com/markshust/hcf",
       "license": "MIT",
       "keywords": ["tdd", "autonomous", "orchestration", "planning", "agents"]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hcf",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Autonomous development orchestration with parallel TDD execution",
   "author": {
     "name": "Mark Shust",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to HCF are documented here. Format follows [Keep a Changelog
 
 ## [Unreleased]
 
+## [2.2.0] — 2026-08-17
+
 ### Added
 - **Configurable plans directory** ([#1](https://github.com/markshust/hcf/pull/1), by [@michielgerritsen](https://github.com/michielgerritsen)). Plans live in `.claude/plans/` unless a project sets `plansDir` in an optional, user-owned `.claude/hcf.json`:
 
@@ -114,7 +116,8 @@ Initial public release.
 - **GitHub issue linking** — `plan-create` captures issue references (`Closes #N`, `Relates to #N`) and `plan-orchestrate` includes them in PR bodies for auto-close on merge.
 - MIT license.
 
-[Unreleased]: https://github.com/markshust/hcf/compare/hcf--v2.1.1...HEAD
+[Unreleased]: https://github.com/markshust/hcf/compare/hcf--v2.2.0...HEAD
+[2.2.0]: https://github.com/markshust/hcf/compare/hcf--v2.1.1...hcf--v2.2.0
 [2.1.1]: https://github.com/markshust/hcf/compare/hcf--v2.1.0...hcf--v2.1.1
 [2.1.0]: https://github.com/markshust/hcf/compare/hcf--v2.0.0...hcf--v2.1.0
 [2.0.0]: https://github.com/markshust/hcf/compare/hcf--v1.1.1...hcf--v2.0.0


### PR DESCRIPTION
Cuts 2.2.0 from #11 (configurable plans directory, superseding #1).

Minor bump: a new opt-in configuration option, no breaking change. Projects without `.claude/hcf.json` behave exactly as on 2.1.1.

- `[Unreleased]` → `[2.2.0] — 2026-08-17`, comparison links updated.
- `version` bumped in both `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`.

After merge: `claude plugin tag --push`, then `gh release create hcf--v2.2.0 --latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)